### PR TITLE
make JamtisPaymentProposal serializable

### DIFF
--- a/src/seraphis_impl/serialization_demo_types.h
+++ b/src/seraphis_impl/serialization_demo_types.h
@@ -56,6 +56,11 @@ namespace sp
 {
 namespace serialization
 {
+/// serializable jamtis::address_index_t
+struct ser_address_index_t final
+{
+    unsigned char bytes[sizeof(jamtis::address_index_t)];
+};
 
 /// serializable jamtis::address_tag_t
 struct ser_address_tag_t final
@@ -433,10 +438,53 @@ struct ser_JamtisDestinationV1 final
     END_SERIALIZE()
 };
 
+/// serializable JamtisPaymentProposalV1
+struct ser_JamtisPaymentProposalV1 final
+{
+    /// destination address
+    ser_JamtisDestinationV1 destination;
+    /// amount
+    rct::xmr_amount amount;
+    /// enote ephemeral private key
+    crypto::x25519_scalar enote_ephemeral_privkey;
+    /// memo elements
+    std::vector<unsigned char> partial_memo;
+
+    BEGIN_SERIALIZE()
+        FIELD(destination)
+        FIELD(amount)
+        FIELD(enote_ephemeral_privkey)
+        FIELD(partial_memo)
+    END_SERIALIZE()
+};
+
+/// serializable JamtisPaymentProposalV1
+struct ser_JamtisPaymentProposalSelfSendV1 final
+{
+    /// destination address
+    ser_JamtisDestinationV1 destination;
+    /// amount
+    rct::xmr_amount amount;
+    /// selfspend type
+    unsigned char type;
+    /// enote ephemeral private key
+    crypto::x25519_scalar enote_ephemeral_privkey;
+    /// memo elements
+    std::vector<unsigned char> partial_memo;
+
+    BEGIN_SERIALIZE()
+        FIELD(destination)
+        FIELD(amount)
+        FIELD(type)
+        FIELD(enote_ephemeral_privkey)
+        FIELD(partial_memo)
+    END_SERIALIZE()
+};
 
 } //namespace serialization
 } //namespace sp
 
+BLOB_SERIALIZER(sp::serialization::ser_address_index_t);
 BLOB_SERIALIZER(sp::serialization::ser_address_tag_t);
 BLOB_SERIALIZER(sp::serialization::ser_encrypted_address_tag_t);
 BLOB_SERIALIZER(sp::serialization::ser_encoded_amount_t);

--- a/src/seraphis_impl/serialization_demo_utils.cpp
+++ b/src/seraphis_impl/serialization_demo_utils.cpp
@@ -37,6 +37,8 @@
 #include "seraphis_core/binned_reference_set.h"
 #include "seraphis_core/discretized_fee.h"
 #include "seraphis_core/jamtis_destination.h"
+#include "seraphis_core/jamtis_payment_proposal.h"
+#include "seraphis_core/jamtis_support_types.h"
 #include "seraphis_crypto/bulletproofs_plus2.h"
 #include "seraphis_crypto/grootle.h"
 #include "seraphis_crypto/sp_composition_proof.h"
@@ -221,6 +223,23 @@ void make_serializable_grootle_proof(const GrootleProof &grootle, ser_GrootlePro
     serializable_grootle_out.X  = grootle.X;
     serializable_grootle_out.zA = grootle.zA;
     serializable_grootle_out.z  = grootle.z;
+}
+//-------------------------------------------------------------------------------------------------------------------
+void make_serializable_jamtis_payment_proposal_v1(const jamtis::JamtisPaymentProposalV1 &payment, ser_JamtisPaymentProposalV1 &serializable_payment_out)
+{
+    make_serializable_sp_destination_v1(payment.destination, serializable_payment_out.destination);
+    serializable_payment_out.amount = payment.amount;
+    serializable_payment_out.enote_ephemeral_privkey = payment.enote_ephemeral_privkey;
+    serializable_payment_out.partial_memo = payment.partial_memo;
+}
+//-------------------------------------------------------------------------------------------------------------------
+void make_serializable_jamtis_payment_proposal_selfsend_v1(const jamtis::JamtisPaymentProposalSelfSendV1 &payment, ser_JamtisPaymentProposalSelfSendV1 &serializable_payment_out)
+{
+    make_serializable_sp_destination_v1(payment.destination, serializable_payment_out.destination);
+    serializable_payment_out.amount = payment.amount;
+    serializable_payment_out.type = static_cast<unsigned char>(payment.type);
+    serializable_payment_out.enote_ephemeral_privkey = payment.enote_ephemeral_privkey;
+    serializable_payment_out.partial_memo = payment.partial_memo;
 }
 //-------------------------------------------------------------------------------------------------------------------
 void make_serializable_sp_composition_proof(const SpCompositionProof &proof,
@@ -433,6 +452,23 @@ void recover_grootle_proof(ser_GrootleProof &serializable_grootle_in, GrootlePro
     grootle_out.X  = std::move(serializable_grootle_in.X);
     grootle_out.zA = serializable_grootle_in.zA;
     grootle_out.z  = serializable_grootle_in.z;
+}
+//-------------------------------------------------------------------------------------------------------------------
+void recover_jamtis_payment_proposal_v1(const ser_JamtisPaymentProposalV1 &serializable_payment, jamtis::JamtisPaymentProposalV1 &payment_out)
+{
+    recover_sp_destination_v1(serializable_payment.destination, payment_out.destination);
+    payment_out.amount = serializable_payment.amount;
+    payment_out.enote_ephemeral_privkey = serializable_payment.enote_ephemeral_privkey;
+    payment_out.partial_memo = serializable_payment.partial_memo;
+}
+//-------------------------------------------------------------------------------------------------------------------
+void recover_jamtis_payment_proposal_selfsend_v1(const ser_JamtisPaymentProposalSelfSendV1 &serializable_payment, jamtis::JamtisPaymentProposalSelfSendV1 &payment_out)
+{
+    recover_sp_destination_v1(serializable_payment.destination, payment_out.destination);
+    payment_out.amount = serializable_payment.amount;
+    payment_out.type = static_cast<jamtis::JamtisSelfSendType>(serializable_payment.type);
+    payment_out.enote_ephemeral_privkey = serializable_payment.enote_ephemeral_privkey;
+    payment_out.partial_memo = serializable_payment.partial_memo;
 }
 //-------------------------------------------------------------------------------------------------------------------
 void recover_sp_composition_proof(const ser_SpCompositionProof &serializable_proof, SpCompositionProof &proof_out)
@@ -700,6 +736,6 @@ void recover_sp_destination_v1(const ser_JamtisDestinationV1 &serializable_desti
         serializable_destination.addr_tag.bytes,
         sizeof(serializable_destination.addr_tag));
 }
-//-------------------------------------------------------------------------------------------------------------------
+
 } //namespace serialization
 } //namespace sp

--- a/src/seraphis_impl/serialization_demo_utils.cpp
+++ b/src/seraphis_impl/serialization_demo_utils.cpp
@@ -736,6 +736,7 @@ void recover_sp_destination_v1(const ser_JamtisDestinationV1 &serializable_desti
         serializable_destination.addr_tag.bytes,
         sizeof(serializable_destination.addr_tag));
 }
+//-------------------------------------------------------------------------------------------------------------------
 
 } //namespace serialization
 } //namespace sp

--- a/src/seraphis_impl/serialization_demo_utils.h
+++ b/src/seraphis_impl/serialization_demo_utils.h
@@ -110,6 +110,8 @@ bool try_get_serializable(epee::span<const std::uint8_t> serialized, Serializabl
 void make_serializable_bpp2(const BulletproofPlus2 &bpp2, ser_BulletproofPlus2_PARTIAL &serializable_bpp2_out);
 void make_serializable_clsag(const rct::clsag &clsag, ser_clsag_PARTIAL &serializable_clsag_out);
 void make_serializable_grootle_proof(const GrootleProof &grootle, ser_GrootleProof &serializable_grootle_out);
+void make_serializable_jamtis_payment_proposal_v1(const jamtis::JamtisPaymentProposalV1 &payment, ser_JamtisPaymentProposalV1 &serializable_payment_out);
+void make_serializable_jamtis_payment_proposal_selfsend_v1(const jamtis::JamtisPaymentProposalSelfSendV1 &payment, ser_JamtisPaymentProposalSelfSendV1 &serializable_payment_out);
 void make_serializable_sp_composition_proof(const SpCompositionProof &proof,
     ser_SpCompositionProof &serializable_proof_out);
 void make_serializable_sp_coinbase_enote_core(const SpCoinbaseEnoteCore &enote,
@@ -148,6 +150,8 @@ void recover_bpp2(ser_BulletproofPlus2_PARTIAL &serializable_bpp2_in,
     BulletproofPlus2 &bpp2_out);
 void recover_clsag(ser_clsag_PARTIAL &serializable_clsag_in, const crypto::key_image &key_image, rct::clsag &clsag_out);
 void recover_grootle_proof(ser_GrootleProof &serializable_grootle_in, GrootleProof &grootle_out);
+void recover_jamtis_payment_proposal_v1(const ser_JamtisPaymentProposalV1 &serializable_payment, jamtis::JamtisPaymentProposalV1 &payment_out);
+void recover_jamtis_payment_proposal_selfsend_v1(const ser_JamtisPaymentProposalSelfSendV1 &serializable_payment, jamtis::JamtisPaymentProposalSelfSendV1 &payment_out);
 void recover_sp_composition_proof(const ser_SpCompositionProof &serializable_proof, SpCompositionProof &proof_out);
 void recover_sp_coinbase_enote_core(const ser_SpCoinbaseEnoteCore &serializable_enote, SpCoinbaseEnoteCore &enote_out);
 void recover_sp_enote_core(const ser_SpEnoteCore &serializable_enote, SpEnoteCore &enote_out);


### PR DESCRIPTION
Thanks for merging this one too. It contains:
- the serialization of the JamtisPaymentProposal struct
- the serialization of ser_address_index_t