### PR TITLE
util to convert legacy outputs to seraphis lib compatible enotes

### DIFF
--- a/src/seraphis_main/enote_record_utils_legacy.h
+++ b/src/seraphis_main/enote_record_utils_legacy.h
@@ -37,6 +37,7 @@
 #include "enote_record_types.h"
 #include "ringct/rctTypes.h"
 #include "seraphis_core/legacy_enote_types.h"
+#include "cryptonote_basic/cryptonote_basic.h"
 
 //third party headers
 
@@ -142,5 +143,11 @@ void get_legacy_enote_record(const LegacyIntermediateEnoteRecord &intermediate_r
     const crypto::secret_key &legacy_spend_privkey,
     hw::device &hwdev,
     LegacyEnoteRecord &record_out);
+/**
+* brief: legacy_outputs_to_enotes - convert legacy tx's "outputs" to Seraphis lib compatible "enotes"
+* param: tx -
+* outparam: enotes_out -
+*/
+void legacy_outputs_to_enotes(const cryptonote::transaction &tx, std::vector<LegacyEnoteVariant> &enotes_out);
 
 } //namespace sp


### PR DESCRIPTION
This type conversion is useful to scan legacy txs (returned via the `/getblocks.bin` RPC endpoint) using the Seraphis wallet lib scanner. Can see it in action in [this commit](https://github.com/j-berman/monero/commit/bc869e230130842b897b3c156f2197823342d0de#diff-b44d1e74cbf7fbfe9405856d1e19ce6389b32f6c2ea7bab6fdd1ac1b8fe85c0b).