### PR TITLE
split variant into variant and optional

### DIFF
--- a/src/async/task_types.h
+++ b/src/async/task_types.h
@@ -86,7 +86,7 @@ struct SimpleTask;
 struct SleepyTask;
 
 /// task
-using TaskVariant = tools::variant<SimpleTask, SleepyTask>;
+using TaskVariant = tools::optional_variant<SimpleTask, SleepyTask>;
 using task_t      = std::function<TaskVariant()>;  //tasks auto-return their continuation (or an empty variant)
 
 //-------------------------------------------------------------------------------------------------------------------

--- a/src/multisig/multisig_signing_errors.h
+++ b/src/multisig/multisig_signing_errors.h
@@ -217,7 +217,7 @@ struct MultisigSigningErrorBadSigSet final
 // MultisigSigningErrorVariant
 ///
 using MultisigSigningErrorVariant =
-    tools::variant<
+    tools::optional_variant<
         MultisigSigningErrorBadInitSet,
         MultisigSigningErrorBadInitSetCollection,
         MultisigSigningErrorAvailableSigners,

--- a/tests/unit_tests/variant.cpp
+++ b/tests/unit_tests/variant.cpp
@@ -38,6 +38,7 @@
 #include <type_traits>
 #include <vector>
 
+using tools::optional_variant;
 using tools::variant;
 using tools::variant_static_visitor;
 
@@ -239,7 +240,7 @@ struct test_stringify_visitor: public variant_static_visitor<std::string>
 //-------------------------------------------------------------------------------------------------------------------
 TEST(variant, operatorbool)
 {
-    variant<int8_t, uint8_t, int16_t, uint16_t, std::string> v;
+    optional_variant<int8_t, uint8_t, int16_t, uint16_t, std::string> v;
     EXPECT_FALSE(v);
     v = (int16_t) 2023;
     EXPECT_TRUE(v);
@@ -251,7 +252,7 @@ TEST(variant, operatorbool)
 //-------------------------------------------------------------------------------------------------------------------
 TEST(variant, is_empty)
 {
-    variant<int8_t, uint8_t, int16_t, uint16_t, std::string> v;
+    optional_variant<int8_t, uint8_t, int16_t, uint16_t, std::string> v;
     EXPECT_TRUE(v.is_empty());
     v = (int16_t) 2023;
     EXPECT_FALSE(v.is_empty());
@@ -260,7 +261,7 @@ TEST(variant, is_empty)
     v = boost::blank{};
     EXPECT_TRUE(v.is_empty());
 
-    variant<> v2;
+    optional_variant<> v2;
     EXPECT_TRUE(v2.is_empty());
     v2 = boost::blank{};
     EXPECT_TRUE(v2.is_empty());


### PR DESCRIPTION
This PR lets us reap the benefit of "optional variants" when we want to have the ability to not have a value with the `optional_variant`, but also we don't have to deal with null cases when we don't want to (which is almost all cases). Null cases are particularly annoying when it comes to dealing with serialization and de serialization. It also makes writing rigid types harder and messier.