### PR TITLE
derive view_balance from master key

### DIFF
--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -305,6 +305,7 @@ namespace config
   const constexpr char HASH_KEY_BINNED_REF_SET_GENERATOR_SEED[] = "binned_refset_generator_seed";
   const constexpr char HASH_KEY_BINNED_REF_SET_MEMBER[] = "binned_refset_member";
 
+  const constexpr char HASH_KEY_JAMTIS_VIEWBALANCE_KEY[] = "jamtis_view_balance_key";
   const constexpr char HASH_KEY_JAMTIS_UNLOCKAMOUNTS_KEY[] = "jamtis_unlock_amounts_key";
   const constexpr char HASH_KEY_JAMTIS_GENERATEADDRESS_SECRET[] = "jamtis_generate_address_secret";
   const constexpr char HASH_KEY_JAMTIS_CIPHERTAG_SECRET[] = "jamtis_cipher_tag_secret";

--- a/src/seraphis_core/jamtis_core_utils.cpp
+++ b/src/seraphis_core/jamtis_core_utils.cpp
@@ -51,6 +51,13 @@ namespace sp
 {
 namespace jamtis
 {
+void make_jamtis_viewbalance_key(const crypto::secret_key &k_master,
+    crypto::secret_key &k_view_balance_out)
+{
+    // k_vb = H_n_x25519[k_m]()
+    SpKDFTranscript transcript{config::HASH_KEY_JAMTIS_VIEWBALANCE_KEY, 0};
+    sp_derive_x25519_key(to_bytes(k_master), transcript.data(), transcript.size(), k_view_balance_out.data);
+}
 //-------------------------------------------------------------------------------------------------------------------
 void make_jamtis_unlockamounts_key(const crypto::secret_key &k_view_balance,
     crypto::x25519_secret_key &xk_unlock_amounts_out)

--- a/src/seraphis_core/jamtis_core_utils.cpp
+++ b/src/seraphis_core/jamtis_core_utils.cpp
@@ -54,7 +54,7 @@ namespace jamtis
 void make_jamtis_viewbalance_key(const crypto::secret_key &k_master,
     crypto::secret_key &k_view_balance_out)
 {
-    // k_vb = H_64[k_m]() mod l
+    // k_vb = H_n[k_m]()
     SpKDFTranscript transcript{config::HASH_KEY_JAMTIS_VIEWBALANCE_KEY, 0};
     sp_derive_key(to_bytes(k_master), transcript.data(), transcript.size(), to_bytes(k_view_balance_out));
 }

--- a/src/seraphis_core/jamtis_core_utils.cpp
+++ b/src/seraphis_core/jamtis_core_utils.cpp
@@ -54,9 +54,9 @@ namespace jamtis
 void make_jamtis_viewbalance_key(const crypto::secret_key &k_master,
     crypto::secret_key &k_view_balance_out)
 {
-    // k_vb = H_n_x25519[k_m]()
+    // k_vb = H_64[k_m]() mod l
     SpKDFTranscript transcript{config::HASH_KEY_JAMTIS_VIEWBALANCE_KEY, 0};
-    sp_derive_x25519_key(to_bytes(k_master), transcript.data(), transcript.size(), k_view_balance_out.data);
+    sp_derive_key(to_bytes(k_master), transcript.data(), transcript.size(), to_bytes(k_view_balance_out));
 }
 //-------------------------------------------------------------------------------------------------------------------
 void make_jamtis_unlockamounts_key(const crypto::secret_key &k_view_balance,

--- a/src/seraphis_core/jamtis_core_utils.h
+++ b/src/seraphis_core/jamtis_core_utils.h
@@ -52,8 +52,8 @@ namespace jamtis
 {
 
 /**
-* brief: make_jamtis_viewbalance_key - view-balance key derived from master for seeing correct account state
-*   k_vb = H_64[k_m]() mod l
+* brief: make_jamtis_viewbalance_key - view-balance key, for viewing all balance information
+*   k_vb = H_n[k_m]()
 * param: k_master - k_m
 * outparam: k_view_balance_out - k_vb
 */

--- a/src/seraphis_core/jamtis_core_utils.h
+++ b/src/seraphis_core/jamtis_core_utils.h
@@ -53,7 +53,7 @@ namespace jamtis
 
 /**
 * brief: make_jamtis_viewbalance_key - view-balance key derived from master for seeing correct account state
-*   k_vb = H_n_x25519[k_m]()
+*   k_vb = H_64[k_m]() mod l
 * param: k_master - k_m
 * outparam: k_view_balance_out - k_vb
 */

--- a/src/seraphis_core/jamtis_core_utils.h
+++ b/src/seraphis_core/jamtis_core_utils.h
@@ -38,7 +38,6 @@
 //local headers
 #include "crypto/crypto.h"
 #include "crypto/x25519.h"
-#include "ringct/rctTypes.h"
 
 //third party headers
 
@@ -52,6 +51,14 @@ namespace sp
 namespace jamtis
 {
 
+/**
+* brief: make_jamtis_viewbalance_key - view-balance key derived from master for seeing correct account state
+*   k_vb = H_n_x25519[k_m]()
+* param: k_master - k_m
+* outparam: k_view_balance_out - k_vb
+*/
+void make_jamtis_viewbalance_key(const crypto::secret_key &k_master,
+    crypto::secret_key &k_view_balance_out);
 /**
 * brief: make_jamtis_unlockamounts_key - unlock-amounts key, for recovering amounts and reconstructing amount commitments
 *   xk_ua = H_n_x25519[k_vb]()


### PR DESCRIPTION
Add view_balance derivation from master key as specified by [KeyDerive1](https://gist.github.com/tevador/50160d160d24cfc6c52ae02eb3d17024#331-curve25519) in the Jamtis spec.