### PR TITLE
seraphis_crypto: split BulletproofPlus2 into proof-only and complete structs

### DIFF
--- a/src/seraphis_crypto/bulletproofs_plus2.h
+++ b/src/seraphis_crypto/bulletproofs_plus2.h
@@ -46,22 +46,29 @@
 namespace sp
 {
 
-struct BulletproofPlus2
+struct BulletproofPlus2Proof
 {
-    rct::keyV V;
     rct::key A, A1, B;
     rct::key r1, s1, d1;
     rct::keyV L, R;
+};
+
+struct BulletproofPlus2
+{
+    rct::keyV V; //! @brief Pederson commitment points multiplied by (1/8)
+    BulletproofPlus2Proof proof;
 };
 
 BulletproofPlus2 bulletproof_plus2_PROVE(const rct::key &v, const rct::key &gamma);
 BulletproofPlus2 bulletproof_plus2_PROVE(uint64_t v, const rct::key &gamma);
 BulletproofPlus2 bulletproof_plus2_PROVE(const rct::keyV &v, const rct::keyV &gamma);
 BulletproofPlus2 bulletproof_plus2_PROVE(const std::vector<uint64_t> &v, const rct::keyV &gamma);
-bool try_get_bulletproof_plus2_verification_data(const std::vector<const BulletproofPlus2*> &proofs,
+bool try_get_bulletproof_plus2_verification_data(const std::vector<const rct::keyV*> &Vs,
+    const std::vector<const BulletproofPlus2Proof*> &proofs,
     std::list<SpMultiexpBuilder> &prep_data_out);
 bool bulletproof_plus2_VERIFY(const BulletproofPlus2 &proof);
-bool bulletproof_plus2_VERIFY(const std::vector<const BulletproofPlus2*> &proofs);
+bool bulletproof_plus2_VERIFY(const std::vector<const rct::keyV*> &Vs,
+    const std::vector<const BulletproofPlus2Proof*> &proofs);
 bool bulletproof_plus2_VERIFY(const std::vector<BulletproofPlus2> &proofs);
 
 } //namespace sp

--- a/src/seraphis_crypto/sp_legacy_proof_helpers.h
+++ b/src/seraphis_crypto/sp_legacy_proof_helpers.h
@@ -72,19 +72,26 @@ void make_bpp2_rangeproofs(const std::vector<rct::xmr_amount> &amounts,
     BulletproofPlus2 &range_proofs_out);
 /**
 * brief: append_bpp2_to_transcript - append BP+ v2 proof to a transcript
-*   transcript += {V} || A || A1 || B || r1 || s1 || d1 || {L} || {R}
+*   transcript += A || A1 || B || r1 || s1 || d1 || {L} || {R}
 * param: bpp_proof -
 * inoutparam: transcript_inout - contents appended to a transcript
 */
-void append_bpp2_to_transcript(const BulletproofPlus2 &bpp_proof, SpTranscriptBuilder &transcript_inout);
+void append_bpp2_proof_to_transcript(const BulletproofPlus2Proof &bpp_proof,
+    SpTranscriptBuilder &transcript_inout);
 /**
-* brief: bpp_size_bytes - get the size of a BP+ proof in bytes
+ * brief: get the size of the BP+ L/R vectors given the number of range proofs
+ *   - L/R length: ceil(log2(64 * num range proofs)
+*/
+std::size_t bpp_lr_length(const std::size_t num_range_proofs);
+/**
+* brief: bpp_size_bytes{_lr} - get the size of a BP+ proof in bytes (excluding commitments)
 *   - BP+ size: 32 * (2*ceil(log2(64 * num range proofs)) + 6)
 * param: num_range_proofs -
-* param: include_commitments -
+* param: lr_length - length of the L/R proof vectors
 * return: the BP+ proof's size in bytes
 */
-std::size_t bpp_size_bytes(const std::size_t num_range_proofs, const bool include_commitments);
+std::size_t bpp_size_bytes(const std::size_t num_range_proofs);
+std::size_t bpp_size_bytes_lr(const std::size_t lr_length);
 /**
 * brief: bpp_weight - get the 'weight' of a BP+ proof
 *   - Verifying a BP+ is linear in the number of aggregated range proofs, but the proof size is logarithmic,
@@ -99,9 +106,10 @@ std::size_t bpp_size_bytes(const std::size_t num_range_proofs, const bool includ
 *   weight = size(proof) + clawback
 *   clawback = 0.8 * [(num range proofs + num dummy range proofs)*size(BP+ proof with 2 range proofs) - size(proof)]
 * param: num_range_proofs -
-* param: include_commitments -
+* param: lr_length - length of the L/R proof vectors
 * return: the BP+ proof's weight
 */
-std::size_t bpp_weight(const std::size_t num_range_proofs, const bool include_commitments);
+std::size_t bpp_weight(const std::size_t num_range_proofs);
+std::size_t bpp_weight_lr(const std::size_t lr_length);
 
 } //namespace sp

--- a/src/seraphis_crypto/sp_legacy_proof_helpers.h
+++ b/src/seraphis_crypto/sp_legacy_proof_helpers.h
@@ -79,12 +79,12 @@ void make_bpp2_rangeproofs(const std::vector<rct::xmr_amount> &amounts,
 void append_bpp2_proof_to_transcript(const BulletproofPlus2Proof &bpp_proof,
     SpTranscriptBuilder &transcript_inout);
 /**
- * brief: get the size of the BP+ L/R vectors given the number of range proofs
+ * brief: bpp_lr_length - get the length of the BP+ L/R vectors, given the number of range proofs
  *   - L/R length: ceil(log2(64 * num range proofs)
 */
 std::size_t bpp_lr_length(const std::size_t num_range_proofs);
 /**
-* brief: bpp_size_bytes{_lr} - get the size of a BP+ proof in bytes (excluding commitments)
+* brief: bpp_size_bytes - get the size of a BP+ proof in bytes (excluding commitments)
 *   - BP+ size: 32 * (2*ceil(log2(64 * num range proofs)) + 6)
 * param: num_range_proofs -
 * param: lr_length - length of the L/R proof vectors

--- a/src/seraphis_impl/serialization_demo_utils.cpp
+++ b/src/seraphis_impl/serialization_demo_utils.cpp
@@ -85,21 +85,6 @@ static void relay_array(const RelayFuncT &relay_func, std::vector<Type1> &array1
 }
 //-------------------------------------------------------------------------------------------------------------------
 //-------------------------------------------------------------------------------------------------------------------
-static void collect_sp_balance_proof_commitments_v1(const std::vector<SpEnoteImageV1> &seraphis_input_images,
-    const std::vector<SpEnoteV1> &output_enotes,
-    std::vector<rct::key> &commitments_out)
-{
-    commitments_out.clear();
-    commitments_out.reserve(seraphis_input_images.size() + output_enotes.size());
-
-    for (const SpEnoteImageV1 &input_image : seraphis_input_images)
-        commitments_out.emplace_back(rct::scalarmultKey(masked_commitment_ref(input_image), rct::INV_EIGHT));
-
-    for (const SpEnoteV1 &output_enote : output_enotes)
-        commitments_out.emplace_back(rct::scalarmultKey(output_enote.core.amount_commitment, rct::INV_EIGHT));
-}
-//-------------------------------------------------------------------------------------------------------------------
-//-------------------------------------------------------------------------------------------------------------------
 static void indices_to_offsets(std::vector<std::uint64_t> &indices_inout)
 {
     if (indices_inout.size() == 0)
@@ -196,16 +181,16 @@ static void make_serializable_sp_membership_proofs_v1(const std::vector<SpMember
 }
 //-------------------------------------------------------------------------------------------------------------------
 //-------------------------------------------------------------------------------------------------------------------
-void make_serializable_bpp2(const BulletproofPlus2 &bpp2, ser_BulletproofPlus2_PARTIAL &serializable_bpp2_out)
+void make_serializable_bpp2(const BulletproofPlus2Proof &bpp2_proof, ser_BulletproofPlus2_PARTIAL &serializable_bpp2_out)
 {
-    serializable_bpp2_out.A  = bpp2.A;
-    serializable_bpp2_out.A1 = bpp2.A1;
-    serializable_bpp2_out.B  = bpp2.B;
-    serializable_bpp2_out.r1 = bpp2.r1;
-    serializable_bpp2_out.s1 = bpp2.s1;
-    serializable_bpp2_out.d1 = bpp2.d1;
-    serializable_bpp2_out.L  = bpp2.L;
-    serializable_bpp2_out.R  = bpp2.R;
+    serializable_bpp2_out.A  = bpp2_proof.A;
+    serializable_bpp2_out.A1 = bpp2_proof.A1;
+    serializable_bpp2_out.B  = bpp2_proof.B;
+    serializable_bpp2_out.r1 = bpp2_proof.r1;
+    serializable_bpp2_out.s1 = bpp2_proof.s1;
+    serializable_bpp2_out.d1 = bpp2_proof.d1;
+    serializable_bpp2_out.L  = bpp2_proof.L;
+    serializable_bpp2_out.R  = bpp2_proof.R;
 }
 //-------------------------------------------------------------------------------------------------------------------
 void make_serializable_clsag(const rct::clsag &clsag, ser_clsag_PARTIAL &serializable_clsag_out)
@@ -422,18 +407,16 @@ void make_serializable_sp_destination_v1(const jamtis::JamtisDestinationV1 &dest
 
 //-------------------------------------------------------------------------------------------------------------------
 void recover_bpp2(ser_BulletproofPlus2_PARTIAL &serializable_bpp2_in,
-    std::vector<rct::key> balance_proof_commitments_mulinv8,
-    BulletproofPlus2 &bpp2_out)
+    BulletproofPlus2Proof &bpp2_proof_out)
 {
-    bpp2_out.V  = std::move(balance_proof_commitments_mulinv8);
-    bpp2_out.A  = serializable_bpp2_in.A;
-    bpp2_out.A1 = serializable_bpp2_in.A1;
-    bpp2_out.B  = serializable_bpp2_in.B;
-    bpp2_out.r1 = serializable_bpp2_in.r1;
-    bpp2_out.s1 = serializable_bpp2_in.s1;
-    bpp2_out.d1 = serializable_bpp2_in.d1;
-    bpp2_out.L  = std::move(serializable_bpp2_in.L);
-    bpp2_out.R  = std::move(serializable_bpp2_in.R);
+    bpp2_proof_out.A  = serializable_bpp2_in.A;
+    bpp2_proof_out.A1 = serializable_bpp2_in.A1;
+    bpp2_proof_out.B  = serializable_bpp2_in.B;
+    bpp2_proof_out.r1 = serializable_bpp2_in.r1;
+    bpp2_proof_out.s1 = serializable_bpp2_in.s1;
+    bpp2_proof_out.d1 = serializable_bpp2_in.d1;
+    bpp2_proof_out.L  = std::move(serializable_bpp2_in.L);
+    bpp2_proof_out.R  = std::move(serializable_bpp2_in.R);
 }
 //-------------------------------------------------------------------------------------------------------------------
 void recover_clsag(ser_clsag_PARTIAL &serializable_clsag_in, const crypto::key_image &key_image, rct::clsag &clsag_out)
@@ -551,11 +534,10 @@ void recover_sp_enote_image_v1(const ser_SpEnoteImageV1 &serializable_image, SpE
 }
 //-------------------------------------------------------------------------------------------------------------------
 void recover_sp_balance_proof_v1(ser_SpBalanceProofV1_PARTIAL &serializable_proof_in,
-    std::vector<rct::key> commitments_inv8,
     SpBalanceProofV1 &proof_out)
 {
     // bpp2
-    recover_bpp2(serializable_proof_in.bpp2_proof_PARTIAL, std::move(commitments_inv8), proof_out.bpp2_proof);
+    recover_bpp2(serializable_proof_in.bpp2_proof_PARTIAL, proof_out.bpp2_proof);
 
     // remainder blinding factor
     proof_out.remainder_blinding_factor = serializable_proof_in.remainder_blinding_factor;
@@ -648,12 +630,7 @@ void recover_sp_tx_squashed_v1(ser_SpTxSquashedV1 &serializable_tx_in,
     relay_array(&recover_sp_enote_v1, serializable_tx_in.outputs, tx_out.outputs);
 
     // balance proof (balance proof and range proofs)
-    std::vector<rct::key> balance_proof_commitments_mulinv8;
-    collect_sp_balance_proof_commitments_v1(tx_out.sp_input_images,
-        tx_out.outputs,
-        balance_proof_commitments_mulinv8);
     recover_sp_balance_proof_v1(serializable_tx_in.balance_proof,
-        std::move(balance_proof_commitments_mulinv8),
         tx_out.balance_proof);
 
     // ring signature proofs: membership and ownership/key-image-legitimacy for each legacy input

--- a/src/seraphis_impl/serialization_demo_utils.h
+++ b/src/seraphis_impl/serialization_demo_utils.h
@@ -107,7 +107,7 @@ bool try_get_serializable(epee::span<const std::uint8_t> serialized, Serializabl
 * param: object - normal object
 * outparam: serializable_object_out - object to map the normal object into; this should be serializable/deserializable
 */
-void make_serializable_bpp2(const BulletproofPlus2 &bpp2, ser_BulletproofPlus2_PARTIAL &serializable_bpp2_out);
+void make_serializable_bpp2(const BulletproofPlus2Proof &bpp2_proof, ser_BulletproofPlus2_PARTIAL &serializable_bpp2_out);
 void make_serializable_clsag(const rct::clsag &clsag, ser_clsag_PARTIAL &serializable_clsag_out);
 void make_serializable_grootle_proof(const GrootleProof &grootle, ser_GrootleProof &serializable_grootle_out);
 void make_serializable_jamtis_payment_proposal_v1(const jamtis::JamtisPaymentProposalV1 &payment, ser_JamtisPaymentProposalV1 &serializable_payment_out);
@@ -146,8 +146,7 @@ void make_serializable_sp_destination_v1(const jamtis::JamtisDestinationV1 &dest
 * outparam: object_out - object to map the serializable object and extra params into
 */
 void recover_bpp2(ser_BulletproofPlus2_PARTIAL &serializable_bpp2_in,
-    std::vector<rct::key> balance_proof_commitments_mulinv8,
-    BulletproofPlus2 &bpp2_out);
+    BulletproofPlus2Proof &bpp2_proof_out);
 void recover_clsag(ser_clsag_PARTIAL &serializable_clsag_in, const crypto::key_image &key_image, rct::clsag &clsag_out);
 void recover_grootle_proof(ser_GrootleProof &serializable_grootle_in, GrootleProof &grootle_out);
 void recover_jamtis_payment_proposal_v1(const ser_JamtisPaymentProposalV1 &serializable_payment, jamtis::JamtisPaymentProposalV1 &payment_out);
@@ -165,7 +164,6 @@ void recover_sp_coinbase_enote_v1(const ser_SpCoinbaseEnoteV1 &serializable_enot
 void recover_sp_enote_v1(const ser_SpEnoteV1 &serializable_enote, SpEnoteV1 &enote_out);
 void recover_sp_enote_image_v1(const ser_SpEnoteImageV1 &serializable_image, SpEnoteImageV1 &image_out);
 void recover_sp_balance_proof_v1(ser_SpBalanceProofV1_PARTIAL &serializable_proof_in,
-    std::vector<rct::key> commitments_inv8,
     SpBalanceProofV1 &proof_out);
 void recover_legacy_ring_signature_v4(ser_LegacyRingSignatureV4_PARTIAL &serializable_signature_in,
     const crypto::key_image &key_image,

--- a/src/seraphis_main/tx_builders_mixed.cpp
+++ b/src/seraphis_main/tx_builders_mixed.cpp
@@ -966,7 +966,7 @@ void make_v1_balance_proof_v1(const std::vector<rct::xmr_amount> &legacy_input_a
     auto vec_wiper = convert_skv_to_rctv(range_proof_blinding_factors, range_proof_amount_commitment_blinding_factors);
     make_bpp2_rangeproofs(range_proof_amounts, range_proof_amount_commitment_blinding_factors, range_proofs);
 
-    balance_proof_out.bpp2_proof = std::move(range_proofs);
+    balance_proof_out.bpp2_proof = std::move(range_proofs.proof);
 
     // 4. set the remainder blinding factor
     // blinding_factor = sum(legacy input blinding factors) + sum(sp input blinding factors) - sum(output blinding factors)

--- a/src/seraphis_main/tx_component_types.cpp
+++ b/src/seraphis_main/tx_component_types.cpp
@@ -218,7 +218,7 @@ void append_to_transcript(const SpImageProofV1 &container, SpTranscriptBuilder &
 //-------------------------------------------------------------------------------------------------------------------
 void append_to_transcript(const SpBalanceProofV1 &container, SpTranscriptBuilder &transcript_inout)
 {
-    append_bpp2_to_transcript(container.bpp2_proof, transcript_inout);
+    append_bpp2_proof_to_transcript(container.bpp2_proof, transcript_inout);
     transcript_inout.append("remainder_blinding_factor", container.remainder_blinding_factor);
 }
 //-------------------------------------------------------------------------------------------------------------------
@@ -227,7 +227,7 @@ std::size_t sp_balance_proof_v1_size_bytes(const std::size_t num_range_proofs)
     std::size_t size{0};
 
     // BP+ proof
-    size += bpp_size_bytes(num_range_proofs, true);  //include commitments
+    size += bpp_size_bytes(num_range_proofs);
 
     // remainder blinding factor
     size += 32;
@@ -237,18 +237,15 @@ std::size_t sp_balance_proof_v1_size_bytes(const std::size_t num_range_proofs)
 //-------------------------------------------------------------------------------------------------------------------
 std::size_t sp_balance_proof_v1_size_bytes(const SpBalanceProofV1 &proof)
 {
-    return sp_balance_proof_v1_size_bytes(proof.bpp2_proof.V.size());
-}
-//-------------------------------------------------------------------------------------------------------------------
-std::size_t sp_balance_proof_v1_size_bytes_compact(const std::size_t num_range_proofs)
-{
-    // proof size minus cached amount commitments
-    return sp_balance_proof_v1_size_bytes(num_range_proofs) - 32*(num_range_proofs);
-}
-//-------------------------------------------------------------------------------------------------------------------
-std::size_t sp_balance_proof_v1_size_bytes_compact(const SpBalanceProofV1 &proof)
-{
-    return sp_balance_proof_v1_size_bytes_compact(proof.bpp2_proof.V.size());
+    std::size_t size{0};
+
+    // BP+ proof
+    size += bpp_size_bytes_lr(proof.bpp2_proof.L.size());
+
+    // remainder blinding factor
+    size += 32;
+
+    return size;
 }
 //-------------------------------------------------------------------------------------------------------------------
 std::size_t sp_balance_proof_v1_weight(const std::size_t num_range_proofs)
@@ -256,7 +253,7 @@ std::size_t sp_balance_proof_v1_weight(const std::size_t num_range_proofs)
     std::size_t weight{0};
 
     // BP+ proof
-    weight += bpp_weight(num_range_proofs, false);  //weight without cached amount commitments
+    weight += bpp_weight(num_range_proofs);  //weight without cached amount commitments
 
     // remainder blinding factor
     weight += 32;
@@ -266,7 +263,15 @@ std::size_t sp_balance_proof_v1_weight(const std::size_t num_range_proofs)
 //-------------------------------------------------------------------------------------------------------------------
 std::size_t sp_balance_proof_v1_weight(const SpBalanceProofV1 &proof)
 {
-    return sp_balance_proof_v1_weight(proof.bpp2_proof.V.size());
+    std::size_t weight{0};
+
+    // BP+ proof
+    weight += bpp_weight_lr(proof.bpp2_proof.L.size());  //weight without cached amount commitments
+
+    // remainder blinding factor
+    weight += 32;
+
+    return weight;
 }
 //-------------------------------------------------------------------------------------------------------------------
 void append_to_transcript(const SpTxSupplementV1 &container, SpTranscriptBuilder &transcript_inout)

--- a/src/seraphis_main/tx_component_types.h
+++ b/src/seraphis_main/tx_component_types.h
@@ -182,21 +182,18 @@ inline std::size_t sp_image_proof_v1_size_bytes() { return sp_composition_size_b
 ///
 struct SpBalanceProofV1 final
 {
-    /// an aggregate set of BP+ proofs
-    BulletproofPlus2 bpp2_proof;
+    /// an aggregate set of BP+ proofs (does not contain V output commitment vector)
+    BulletproofPlus2Proof bpp2_proof;
     /// the remainder blinding factor
     rct::key remainder_blinding_factor;
 };
 inline const boost::string_ref container_name(const SpBalanceProofV1&) { return "SpBalanceProofV1"; }
 void append_to_transcript(const SpBalanceProofV1 &container, SpTranscriptBuilder &transcript_inout);
 
-/// get the size in bytes
-/// - note: the compact version does not include the bulletproof's cached amount commitments
+/// get the proof size in bytes (does not include commitment values)
 std::size_t sp_balance_proof_v1_size_bytes(const std::size_t num_range_proofs);
 std::size_t sp_balance_proof_v1_size_bytes(const SpBalanceProofV1 &proof);
-std::size_t sp_balance_proof_v1_size_bytes_compact(const std::size_t num_range_proofs);
-std::size_t sp_balance_proof_v1_size_bytes_compact(const SpBalanceProofV1 &proof);
-/// get the proof weight (using compact size)
+/// get the proof weight
 std::size_t sp_balance_proof_v1_weight(const std::size_t num_range_proofs);
 std::size_t sp_balance_proof_v1_weight(const SpBalanceProofV1 &proof);
 

--- a/src/seraphis_main/tx_validators.cpp
+++ b/src/seraphis_main/tx_validators.cpp
@@ -123,8 +123,7 @@ bool validate_sp_semantics_component_counts_v1(const SemanticConfigComponentCoun
     const std::size_t num_sp_membership_proofs,
     const std::size_t num_sp_image_proofs,
     const std::size_t num_outputs,
-    const std::size_t num_enote_pubkeys,
-    const std::size_t num_range_proofs)
+    const std::size_t num_enote_pubkeys)
 {
     // input count
     if (num_legacy_input_images + num_sp_input_images < config.min_inputs ||
@@ -146,10 +145,6 @@ bool validate_sp_semantics_component_counts_v1(const SemanticConfigComponentCoun
     // output count
     if (num_outputs < config.min_outputs ||
         num_outputs > config.max_outputs)
-        return false;
-
-    // range proofs should be 1:1 with seraphis input image amount commitments and outputs
-    if (num_range_proofs != num_sp_input_images + num_outputs)
         return false;
 
     // outputs and enote pubkeys should be 1:1
@@ -430,10 +425,8 @@ bool validate_sp_amount_balance_v1(const std::vector<LegacyEnoteImageV2> &legacy
     const DiscretizedFee discretized_transaction_fee,
     const SpBalanceProofV1 &balance_proof)
 {
-    const BulletproofPlus2 &range_proofs = balance_proof.bpp2_proof;
-
     // sanity check
-    if (range_proofs.V.size() == 0)
+    if (outputs.size() == 0)
         return false;
 
     // try to extract the fee
@@ -448,26 +441,6 @@ bool validate_sp_amount_balance_v1(const std::vector<LegacyEnoteImageV2> &legacy
             raw_transaction_fee,
             balance_proof.remainder_blinding_factor))
         return false;
-
-    // check that commitments in range proofs line up with seraphis input image and output commitments
-    if (sp_input_images.size() + outputs.size() != range_proofs.V.size())
-        return false;
-
-    for (std::size_t input_commitment_index{0}; input_commitment_index < sp_input_images.size(); ++input_commitment_index)
-    {
-        // the two stored copies of input image commitments must match
-        if (!(masked_commitment_ref(sp_input_images[input_commitment_index]) ==
-                rct::scalarmult8(range_proofs.V[input_commitment_index])))
-            return false;
-    }
-
-    for (std::size_t output_commitment_index{0}; output_commitment_index < outputs.size(); ++output_commitment_index)
-    {
-        // the two stored copies of output commitments must match
-        if (!(outputs[output_commitment_index].core.amount_commitment ==
-                rct::scalarmult8(range_proofs.V[sp_input_images.size() + output_commitment_index])))
-            return false;
-    }
 
     // BP+: deferred for batch-verification
 

--- a/src/seraphis_main/tx_validators.h
+++ b/src/seraphis_main/tx_validators.h
@@ -120,7 +120,6 @@ bool validate_sp_semantics_coinbase_component_counts_v1(const SemanticConfigCoin
 * param: num_sp_image_proofs -
 * param: num_outputs -
 * param: num_enote_pubkeys -
-* param: num_range_proofs -
 * return: true/false on validation result
 */
 bool validate_sp_semantics_component_counts_v1(const SemanticConfigComponentCountsV1 &config,
@@ -130,8 +129,7 @@ bool validate_sp_semantics_component_counts_v1(const SemanticConfigComponentCoun
     const std::size_t num_sp_membership_proofs,
     const std::size_t num_sp_image_proofs,
     const std::size_t num_outputs,
-    const std::size_t num_enote_pubkeys,
-    const std::size_t num_range_proofs);
+    const std::size_t num_enote_pubkeys);
 /**
 * brief: validate_sp_semantics_legacy_reference_sets_v1 - check legacy ring signatures have consistent and
 *   valid reference sets
@@ -252,6 +250,7 @@ bool validate_sp_coinbase_amount_balance_v1(const rct::xmr_amount block_reward,
 * param: outputs -
 * param: discretized_transaction_fee -
 * param: balance_proof -
+* param: sp_tx_commitments -
 * return: true/false on validation result
 */
 bool validate_sp_amount_balance_v1(const std::vector<LegacyEnoteImageV2> &legacy_input_images,

--- a/src/seraphis_main/txtype_squashed_v1.cpp
+++ b/src/seraphis_main/txtype_squashed_v1.cpp
@@ -91,7 +91,7 @@ std::size_t sp_tx_squashed_v1_size_bytes(const std::size_t num_legacy_inputs,
     size += num_outputs * sp_enote_v1_size_bytes();
 
     // balance proof (note: only seraphis inputs and outputs are range proofed)
-    size += sp_balance_proof_v1_size_bytes_compact(num_sp_inputs + num_outputs);
+    size += sp_balance_proof_v1_size_bytes(num_sp_inputs + num_outputs);
 
     // legacy ring signatures
     size += num_legacy_inputs * legacy_ring_signature_v4_size_bytes(legacy_ring_size);
@@ -166,7 +166,7 @@ std::size_t sp_tx_squashed_v1_weight(const std::size_t num_legacy_inputs,
         };
 
     // subtract balance proof size and add its weight
-    weight -= sp_balance_proof_v1_size_bytes_compact(num_sp_inputs + num_outputs);
+    weight -= sp_balance_proof_v1_size_bytes(num_sp_inputs + num_outputs);
     weight += sp_balance_proof_v1_weight(num_sp_inputs + num_outputs);
 
     return weight;
@@ -530,8 +530,7 @@ bool validate_tx_semantics<SpTxSquashedV1>(const SpTxSquashedV1 &tx)
             tx.sp_membership_proofs.size(),
             tx.sp_image_proofs.size(),
             tx.outputs.size(),
-            tx.tx_supplement.output_enote_ephemeral_pubkeys.size(),
-            tx.balance_proof.bpp2_proof.V.size()))
+            tx.tx_supplement.output_enote_ephemeral_pubkeys.size()))
         return false;
 
     // validate legacy input proof reference set sizes
@@ -624,9 +623,13 @@ bool validate_txs_batchable<SpTxSquashedV1>(const std::vector<const SpTxSquashed
 {
     std::vector<const SpMembershipProofV1*> sp_membership_proof_ptrs;
     std::vector<const SpEnoteImageCore*> sp_input_image_ptrs;
-    std::vector<const BulletproofPlus2*> range_proof_ptrs;
+    std::vector<rct::keyV> tx_commitments;
+    std::vector<const rct::keyV*> tx_commitments_ptrs;
+    std::vector<const BulletproofPlus2Proof*> range_proof_ptrs;
     sp_membership_proof_ptrs.reserve(txs.size()*20);  //heuristic... (most txs have 1-2 seraphis inputs)
     sp_input_image_ptrs.reserve(txs.size()*20);
+    tx_commitments.reserve(txs.size());
+    tx_commitments_ptrs.reserve(txs.size());
     range_proof_ptrs.reserve(txs.size());
 
     // prepare for batch-verification
@@ -635,12 +638,31 @@ bool validate_txs_batchable<SpTxSquashedV1>(const std::vector<const SpTxSquashed
         if (!tx)
             return false;
 
+        // used to gather all new tx commitments (sp enote image masked, then enote outputs)
+        rct::keyV &curr_tx_commitments = tools::add_element(tx_commitments);
+        curr_tx_commitments.reserve(tx->sp_input_images.size() + tx->outputs.size());
+
         // gather membership proof pieces
         for (const SpMembershipProofV1 &sp_membership_proof : tx->sp_membership_proofs)
             sp_membership_proof_ptrs.push_back(&sp_membership_proof);
 
+        // gather enote images and also their masked commitments (mul 1/8)
         for (const SpEnoteImageV1 &sp_input_image : tx->sp_input_images)
+        {
             sp_input_image_ptrs.push_back(&(sp_input_image.core));
+            curr_tx_commitments.push_back(rct::scalarmultKey(masked_commitment_ref(sp_input_image),
+                rct::INV_EIGHT));
+        }
+
+        // make keyV for all output commitments (mul 1/8)
+        for (const SpEnoteV1 &sp_output_enote : tx->outputs)
+        {
+            curr_tx_commitments.push_back(rct::scalarmultKey(sp_output_enote.core.amount_commitment,
+                rct::INV_EIGHT));
+        }
+
+        // gather tx commitment pointers
+        tx_commitments_ptrs.push_back(&curr_tx_commitments);
 
         // gather range proofs
         range_proof_ptrs.push_back(&(tx->balance_proof.bpp2_proof));
@@ -658,7 +680,8 @@ bool validate_txs_batchable<SpTxSquashedV1>(const std::vector<const SpTxSquashed
 
     // range proofs
     std::list<SpMultiexpBuilder> validation_data_range_proofs;
-    if (!try_get_bulletproof_plus2_verification_data(range_proof_ptrs, validation_data_range_proofs))
+    if (!try_get_bulletproof_plus2_verification_data(tx_commitments_ptrs, range_proof_ptrs,
+            validation_data_range_proofs))
         return false;
 
     // batch verify

--- a/src/seraphis_main/txtype_squashed_v1.cpp
+++ b/src/seraphis_main/txtype_squashed_v1.cpp
@@ -661,12 +661,13 @@ bool validate_txs_batchable<SpTxSquashedV1>(const std::vector<const SpTxSquashed
                 rct::INV_EIGHT));
         }
 
-        // gather tx commitment pointers
-        tx_commitments_ptrs.push_back(&curr_tx_commitments);
-
         // gather range proofs
         range_proof_ptrs.push_back(&(tx->balance_proof.bpp2_proof));
     }
+
+    // gather pointers to tx commitment lists (we do this after done modifying tx_commitments)
+    for (const auto &cvec : tx_commitments)
+        tx_commitments_ptrs.push_back(&cvec);
 
     // batch verification: collect pippenger data sets for an aggregated multiexponentiation
 

--- a/tests/unit_tests/bulletproofs_plus2.cpp
+++ b/tests/unit_tests/bulletproofs_plus2.cpp
@@ -139,31 +139,31 @@ TEST(bulletproofs_plus2, invalid_torsion)
       ASSERT_FALSE(sp::bulletproof_plus2_VERIFY(proof));
       k = org_k;
     }
-    for (auto &k: proof.L)
+    for (auto &k: proof.proof.L)
     {
       const rct::key org_k = k;
       rct::addKeys(k, org_k, x);
       ASSERT_FALSE(sp::bulletproof_plus2_VERIFY(proof));
       k = org_k;
     }
-    for (auto &k: proof.R)
+    for (auto &k: proof.proof.R)
     {
       const rct::key org_k = k;
       rct::addKeys(k, org_k, x);
       ASSERT_FALSE(sp::bulletproof_plus2_VERIFY(proof));
       k = org_k;
     }
-    const rct::key org_A = proof.A;
-    rct::addKeys(proof.A, org_A, x);
+    const rct::key org_A = proof.proof.A;
+    rct::addKeys(proof.proof.A, org_A, x);
     ASSERT_FALSE(sp::bulletproof_plus2_VERIFY(proof));
-    proof.A = org_A;
-    const rct::key org_A1 = proof.A1;
-    rct::addKeys(proof.A1, org_A1, x);
+    proof.proof.A = org_A;
+    const rct::key org_A1 = proof.proof.A1;
+    rct::addKeys(proof.proof.A1, org_A1, x);
     ASSERT_FALSE(sp::bulletproof_plus2_VERIFY(proof));
-    proof.A1 = org_A1;
-    const rct::key org_B = proof.B;
-    rct::addKeys(proof.B, org_B, x);
+    proof.proof.A1 = org_A1;
+    const rct::key org_B = proof.proof.B;
+    rct::addKeys(proof.proof.B, org_B, x);
     ASSERT_FALSE(sp::bulletproof_plus2_VERIFY(proof));
-    proof.B = org_B;
+    proof.proof.B = org_B;
   }
 }


### PR DESCRIPTION
In `SpTxSquashedV1`, we have commitments (sp enote image and output), and we have a balance proof. However, the commitments were stored doubly, inside the in/out lists, and inside the proof. This PR splits up the Bulletproof into two parts: the values we are committing to/verifying, and the proof itself. Now inside the `SpBalanceProofV1`, we store just the proof, and not the committed values. Doing this has many positive effects for code quality. First, it is now immediately clear to a new reader that the balance proof won't hold commitments; they "belong" to either an enote image or an output. Secondly, downstream developers cannot set bulletproof commitments points, so they can't screw up the 1/8 multiply. Thirdly, this setup makes the transaction format more "rigid": there are fewer fields that conflict with each other and there is less room for making silly mistakes based on assumptions that all fields are important and will change outputs of functions. For a real world example of what I mean, look at PR fix https://github.com/monero-project/monero/pull/8707. There was a cache coded for RingCT signatures with the assumption that changing certain fields of the RingCT signatures would lead to a different serialization, and thus changing fields would invalidate the cache. This was NOT the case, and the cache would have added in an inflation bug if not for a technicality in the way that RingCT signatures were deserialized and "expanded" using different elements of the `cryptonote::transaction` class. If `cryptonote::transaction` perhaps had a more rigid way of constructing the signatures, it wouldn't have been a problem in the first place. This is the main goal of this PR: minimize potential future risky behavior.

One thing that needs to be double-checked in this PR is that all commitments are bound to in some part of the TXID. 

Depends on #30 