### PR TITLE
serialization: protect blob serialization from undefined behavior

### DIFF
--- a/src/ringct/rctTypes.h
+++ b/src/ringct/rctTypes.h
@@ -767,7 +767,7 @@ namespace std
 BLOB_SERIALIZER(rct::key);
 BLOB_SERIALIZER(rct::key64);
 BLOB_SERIALIZER(rct::ctkey);
-BLOB_SERIALIZER(rct::multisig_kLRki);
+BLOB_SERIALIZER_FORCED(rct::multisig_kLRki);
 BLOB_SERIALIZER(rct::boroSig);
 
 VARIANT_TAG(debug_archive, rct::key, "rct::key");

--- a/src/serialization/crypto.h
+++ b/src/serialization/crypto.h
@@ -83,7 +83,7 @@ BLOB_SERIALIZER(crypto::chacha_iv);
 BLOB_SERIALIZER(crypto::hash);
 BLOB_SERIALIZER(crypto::hash8);
 BLOB_SERIALIZER(crypto::public_key);
-BLOB_SERIALIZER(crypto::secret_key);
+BLOB_SERIALIZER_FORCED(crypto::secret_key);
 BLOB_SERIALIZER(crypto::key_derivation);
 BLOB_SERIALIZER(crypto::key_image);
 BLOB_SERIALIZER(crypto::signature);

--- a/src/serialization/serialization.h
+++ b/src/serialization/serialization.h
@@ -50,12 +50,15 @@
 #include <boost/type_traits/integral_constant.hpp>
 #include <boost/mpl/bool.hpp>
 
-/*! \struct is_blob_type 
+/*! \struct is_blob_type / is_blob_forced
  *
- * \brief a descriptor for dispatching serialize
+ * \brief descriptors for dispatching serialize: whether to take byte-wise copy/store to type
  */
 template <class T>
 struct is_blob_type { typedef boost::false_type type; };
+
+template <class T>
+struct is_blob_forced: std::false_type {};
 
 /*! \fn do_serialize(Archive &ar, T &v)
  *
@@ -68,6 +71,8 @@ struct is_blob_type { typedef boost::false_type type; };
 template <class Archive, class T>
 inline std::enable_if_t<is_blob_type<T>::type::value, bool> do_serialize(Archive &ar, T &v)
 {
+  static_assert(std::is_trivially_copyable<T>() || is_blob_forced<T>(),
+    "sanity check: types that can't be trivially copied shouldn't be using the blob serializer");
   ar.serialize_blob(&v, sizeof(v));
   return true;
 }
@@ -100,6 +105,15 @@ inline bool do_serialize(Archive &ar, bool &v)
   struct is_blob_type<T> {						\
     typedef boost::true_type type;					\
   }
+
+/*! \macro BLOB_SERIALIZER_FORCED
+ *
+ * \brief makes the type have a blob serializer trait defined, even if it isn't trivially copyable
+ */
+#define BLOB_SERIALIZER_FORCED(T) \
+  BLOB_SERIALIZER(T);             \
+  template<>                      \
+  struct is_blob_forced<T>: std::true_type {};
 
 /*! \macro VARIANT_TAG
  *

--- a/tests/unit_tests/serialization.cpp
+++ b/tests/unit_tests/serialization.cpp
@@ -51,6 +51,11 @@
 using namespace std;
 using namespace crypto;
 
+static_assert(!std::is_trivially_copyable<std::vector<unsigned char>>(),
+  "should fail to compile when applying blob serializer");
+static_assert(!std::is_trivially_copyable<std::string>(),
+  "should fail to compile when applying blob serializer");
+
 struct Struct
 {
   int32_t a;


### PR DESCRIPTION
There is currently no compiler protection when someone tries to do (for example) `BLOB_SERIALIZER(std::vector<int>)`. You just get runtime allocation errors. This has already eaten up dev time before, so this PR adds a static assertion that the type must be trivially copyable, as defined by the C++ standard. Types can override this if applicable if they use `BLOB_SERIALIZER_FORCED`.