### PR TITLE
Remaining tx ridigity issues

### DIFF
--- a/src/seraphis_crypto/sp_legacy_proof_helpers.cpp
+++ b/src/seraphis_crypto/sp_legacy_proof_helpers.cpp
@@ -77,14 +77,6 @@ static std::size_t highest_bit_position(std::size_t num)
 }
 //-------------------------------------------------------------------------------------------------------------------
 //-------------------------------------------------------------------------------------------------------------------
-void append_clsag_to_transcript(const rct::clsag &clsag_proof, SpTranscriptBuilder &transcript_inout)
-{
-    transcript_inout.append("s", clsag_proof.s);
-    transcript_inout.append("c1", clsag_proof.c1);
-    transcript_inout.append("I", clsag_proof.I);
-    transcript_inout.append("D", clsag_proof.D);
-}
-//-------------------------------------------------------------------------------------------------------------------
 std::size_t clsag_size_bytes(const std::size_t ring_size)
 {
     return 32 * (ring_size + 2);  //does not include 'I', which is treated as a cached value here

--- a/src/seraphis_crypto/sp_legacy_proof_helpers.h
+++ b/src/seraphis_crypto/sp_legacy_proof_helpers.h
@@ -45,14 +45,6 @@ namespace sp { class SpTranscriptBuilder; }
 
 namespace sp
 {
-
-/**
-* brief: append_clsag_to_transcript - append CLSAG proof to a transcript
-*   transcript += {s} || c1 || I || D
-* param: clsag_proof -
-* inoutparam: transcript_inout - contents appended to a transcript
-*/
-void append_clsag_to_transcript(const rct::clsag &clsag_proof, SpTranscriptBuilder &transcript_inout);
 /**
 * brief: clsag_size_bytes - get the size of a CLSAG proof in bytes
 *   - CLSAG size: 32 * (ring size + 2)

--- a/src/seraphis_impl/serialization_demo_utils.h
+++ b/src/seraphis_impl/serialization_demo_utils.h
@@ -36,7 +36,6 @@
 //local headers
 #include "crypto/crypto.h"
 #include "ringct/rctTypes.h"
-#include "seraphis_core/binned_reference_set.h"
 #include "seraphis_core/discretized_fee.h"
 #include "seraphis_core/jamtis_destination.h"
 #include "seraphis_core/sp_core_types.h"
@@ -108,7 +107,7 @@ bool try_get_serializable(epee::span<const std::uint8_t> serialized, Serializabl
 * outparam: serializable_object_out - object to map the normal object into; this should be serializable/deserializable
 */
 void make_serializable_bpp2(const BulletproofPlus2Proof &bpp2_proof, ser_BulletproofPlus2_PARTIAL &serializable_bpp2_out);
-void make_serializable_clsag(const rct::clsag &clsag, ser_clsag_PARTIAL &serializable_clsag_out);
+void make_serializable_clsag(const LegacyClsagProof &clsag, ser_LegacyClsagProof &serializable_clsag_out);
 void make_serializable_grootle_proof(const GrootleProof &grootle, ser_GrootleProof &serializable_grootle_out);
 void make_serializable_jamtis_payment_proposal_v1(const jamtis::JamtisPaymentProposalV1 &payment, ser_JamtisPaymentProposalV1 &serializable_payment_out);
 void make_serializable_jamtis_payment_proposal_selfsend_v1(const jamtis::JamtisPaymentProposalSelfSendV1 &payment, ser_JamtisPaymentProposalSelfSendV1 &serializable_payment_out);
@@ -118,8 +117,6 @@ void make_serializable_sp_coinbase_enote_core(const SpCoinbaseEnoteCore &enote,
     ser_SpCoinbaseEnoteCore &serializable_enote_out);
 void make_serializable_sp_enote_core(const SpEnoteCore &enote, ser_SpEnoteCore &serializable_enote_out);
 void make_serializable_sp_enote_image_core(const SpEnoteImageCore &image, ser_SpEnoteImageCore &serializable_image_out);
-void make_serializable_sp_binned_reference_set_v1(const SpBinnedReferenceSetV1 &refset,
-    ser_SpBinnedReferenceSetV1_PARTIAL &serializable_refset_out);
 void make_serializable_legacy_enote_image_v2(const LegacyEnoteImageV2 &image,
     ser_LegacyEnoteImageV2 &serializable_image_out);
 void make_serializable_sp_enote_v1(const SpEnoteV1 &enote, ser_SpEnoteV1 &serializable_enote_out);
@@ -127,9 +124,9 @@ void make_serializable_sp_enote_image_v1(const SpEnoteImageV1 &image, ser_SpEnot
 void make_serializable_sp_balance_proof_v1(const SpBalanceProofV1 &proof,
     ser_SpBalanceProofV1_PARTIAL &serializable_proof_out);
 void make_serializable_legacy_ring_signature_v4(const LegacyRingSignatureV4 &signature,
-    ser_LegacyRingSignatureV4_PARTIAL &serializable_signature_out);
+    ser_LegacyRingSignatureV4 &serializable_signature_out);
 void make_serializable_sp_membership_proof_v1(const SpMembershipProofV1 &proof,
-    ser_SpMembershipProofV1_PARTIAL &serializable_proof_out);
+    ser_SpMembershipProofV1 &serializable_proof_out);
 void make_serializable_sp_image_proof_v1(const SpImageProofV1 &image_proof,
     ser_SpImageProofV1 &serializable_image_proof_out);
 void make_serializable_sp_tx_supplement_v1(const SpTxSupplementV1 &supplement,
@@ -147,7 +144,7 @@ void make_serializable_sp_destination_v1(const jamtis::JamtisDestinationV1 &dest
 */
 void recover_bpp2(ser_BulletproofPlus2_PARTIAL &serializable_bpp2_in,
     BulletproofPlus2Proof &bpp2_proof_out);
-void recover_clsag(ser_clsag_PARTIAL &serializable_clsag_in, const crypto::key_image &key_image, rct::clsag &clsag_out);
+void recover_clsag(ser_LegacyClsagProof &serializable_clsag_in, LegacyClsagProof &clsag_out);
 void recover_grootle_proof(ser_GrootleProof &serializable_grootle_in, GrootleProof &grootle_out);
 void recover_jamtis_payment_proposal_v1(const ser_JamtisPaymentProposalV1 &serializable_payment, jamtis::JamtisPaymentProposalV1 &payment_out);
 void recover_jamtis_payment_proposal_selfsend_v1(const ser_JamtisPaymentProposalSelfSendV1 &serializable_payment, jamtis::JamtisPaymentProposalSelfSendV1 &payment_out);
@@ -155,40 +152,21 @@ void recover_sp_composition_proof(const ser_SpCompositionProof &serializable_pro
 void recover_sp_coinbase_enote_core(const ser_SpCoinbaseEnoteCore &serializable_enote, SpCoinbaseEnoteCore &enote_out);
 void recover_sp_enote_core(const ser_SpEnoteCore &serializable_enote, SpEnoteCore &enote_out);
 void recover_sp_enote_image_core(const ser_SpEnoteImageCore &serializable_image, SpEnoteImageCore &image_out);
-void recover_sp_binned_reference_set_v1(ser_SpBinnedReferenceSetV1_PARTIAL &serializable_refset_in,
-    const SpBinnedReferenceSetConfigV1 &bin_config,
-    const rct::key &generator_seed,
-    SpBinnedReferenceSetV1 &refset_out);
 void recover_legacy_enote_image_v2(const ser_LegacyEnoteImageV2 &serializable_image, LegacyEnoteImageV2 &image_out);
 void recover_sp_coinbase_enote_v1(const ser_SpCoinbaseEnoteV1 &serializable_enote, SpCoinbaseEnoteV1 &enote_out);
 void recover_sp_enote_v1(const ser_SpEnoteV1 &serializable_enote, SpEnoteV1 &enote_out);
 void recover_sp_enote_image_v1(const ser_SpEnoteImageV1 &serializable_image, SpEnoteImageV1 &image_out);
 void recover_sp_balance_proof_v1(ser_SpBalanceProofV1_PARTIAL &serializable_proof_in,
     SpBalanceProofV1 &proof_out);
-void recover_legacy_ring_signature_v4(ser_LegacyRingSignatureV4_PARTIAL &serializable_signature_in,
-    const crypto::key_image &key_image,
+void recover_legacy_ring_signature_v4(ser_LegacyRingSignatureV4 &serializable_signature_in,
     LegacyRingSignatureV4 &signature_out);
-void recover_sp_membership_proof_v1(ser_SpMembershipProofV1_PARTIAL &serializable_proof_in,
-    const SpBinnedReferenceSetConfigV1 &bin_config,
-    const rct::key &generator_seed,
-    const std::size_t ref_set_decomp_n,
-    const std::size_t ref_set_decomp_m,
+void recover_sp_membership_proof_v1(ser_SpMembershipProofV1 &serializable_proof_in,
     SpMembershipProofV1 &proof_out);
 void recover_sp_image_proof_v1(const ser_SpImageProofV1 &serializable_image_proof, SpImageProofV1 &image_proof_out);
 void recover_sp_tx_supplement_v1(ser_SpTxSupplementV1 &serializable_supplement_in, SpTxSupplementV1 &supplement_out);
 void recover_discretized_fee(const unsigned char serializable_discretized_fee, DiscretizedFee &discretized_fee_out);
 void recover_sp_tx_coinbase_v1(ser_SpTxCoinbaseV1 &serializable_tx_in, SpTxCoinbaseV1 &tx_out);
-void recover_sp_tx_squashed_v1(ser_SpTxSquashedV1 &serializable_tx_in,
-    const SpBinnedReferenceSetConfigV1 &sp_refset_bin_config,
-    const std::size_t sp_ref_set_decomp_n,
-    const std::size_t sp_ref_set_decomp_m,
-    SpTxSquashedV1 &tx_out);
 void recover_sp_tx_squashed_v1(ser_SpTxSquashedV1 &serializable_tx_in, SpTxSquashedV1 &tx_out);
-bool try_recover_sp_tx_squashed_v1(ser_SpTxSquashedV1 &serializable_tx_in,
-    const SpBinnedReferenceSetConfigV1 &sp_refset_bin_config,
-    const std::size_t sp_ref_set_decomp_n,
-    const std::size_t sp_ref_set_decomp_m,
-    SpTxSquashedV1 &tx_out);
 bool try_recover_sp_tx_squashed_v1(ser_SpTxSquashedV1 &serializable_tx_in, SpTxSquashedV1 &tx_out);
 void recover_sp_destination_v1(const ser_JamtisDestinationV1 &serializable_destination, jamtis::JamtisDestinationV1 &dest_out);
 

--- a/src/seraphis_main/tx_builders_inputs.cpp
+++ b/src/seraphis_main/tx_builders_inputs.cpp
@@ -600,9 +600,8 @@ void make_v1_membership_proof_v1(const std::size_t ref_set_decomp_n,
 
 
     /// copy miscellaneous components
-    membership_proof_out.binned_reference_set = std::move(binned_reference_set);
-    membership_proof_out.ref_set_decomp_n     = ref_set_decomp_n;
-    membership_proof_out.ref_set_decomp_m     = ref_set_decomp_m;
+    membership_proof_out.bin_loci            = std::move(binned_reference_set.bin_loci);
+    membership_proof_out.bin_rotation_factor = binned_reference_set.bin_rotation_factor;
 }
 //-------------------------------------------------------------------------------------------------------------------
 void make_v1_membership_proof_v1(SpMembershipProofPrepV1 membership_proof_prep, SpMembershipProofV1 &membership_proof_out)
@@ -656,6 +655,36 @@ void make_v1_alignable_membership_proofs_v1(std::vector<SpMembershipProofPrepV1>
 
     for (SpMembershipProofPrepV1 &proof_prep : membership_proof_preps)
         make_v1_alignable_membership_proof_v1(std::move(proof_prep), tools::add_element(alignable_membership_proofs_out));
+}
+//-------------------------------------------------------------------------------------------------------------------
+void make_binned_ref_set_v1(const SpMembershipProofV1 &membership_proof,
+    const SpBinnedReferenceSetConfigV1 &ref_set_config,
+    const rct::key &bin_generator_seed,
+    SpBinnedReferenceSetV1 &binned_ref_set_out)
+{
+    binned_ref_set_out = SpBinnedReferenceSetV1{
+        .bin_config = ref_set_config,
+        .bin_generator_seed = bin_generator_seed,
+        .bin_rotation_factor = membership_proof.bin_rotation_factor,
+        .bin_loci = membership_proof.bin_loci
+    };
+}
+//-------------------------------------------------------------------------------------------------------------------
+void make_binned_ref_set_v1(const SpMembershipProofV1 &membership_proof,
+    const SpBinnedReferenceSetConfigV1 &ref_set_config,
+    const SpEnoteImageCore &enote_image,
+    SpBinnedReferenceSetV1 &binned_ref_set_out)
+{
+    // bin_generator_seed = H_32(K", C")
+    rct::key bin_generator_seed;
+    make_binned_ref_set_generator_seed_v1(enote_image.masked_address,
+        enote_image.masked_commitment,
+        bin_generator_seed);
+
+    return make_binned_ref_set_v1(membership_proof,
+        ref_set_config,
+        bin_generator_seed,
+        binned_ref_set_out);
 }
 //-------------------------------------------------------------------------------------------------------------------
 void align_v1_membership_proofs_v1(const std::vector<SpEnoteImageV1> &input_images,

--- a/src/seraphis_main/tx_builders_inputs.h
+++ b/src/seraphis_main/tx_builders_inputs.h
@@ -278,6 +278,17 @@ void make_v1_alignable_membership_proof_v1(SpMembershipProofPrepV1 membership_pr
 void make_v1_alignable_membership_proofs_v1(std::vector<SpMembershipProofPrepV1> membership_proof_preps,
     std::vector<SpAlignableMembershipProofV1> &alignable_membership_proof_out);
 /**
+ * brief: make_binned_ref_set_v1 - use membership proof, refset config, and gen seed to make binned reference set
+*/
+void make_binned_ref_set_v1(const SpMembershipProofV1 &membership_proof,
+    const SpBinnedReferenceSetConfigV1 &ref_set_config,
+    const rct::key &bin_generator_seed,
+    SpBinnedReferenceSetV1 &binned_ref_set_out);
+void make_binned_ref_set_v1(const SpMembershipProofV1 &membership_proof,
+    const SpBinnedReferenceSetConfigV1 &ref_set_config,
+    const SpEnoteImageCore &enote_image,
+    SpBinnedReferenceSetV1 &binned_ref_set_out);
+/**
 * brief: align_v1_membership_proofs_v1 - rearrange seraphis membership proofs so they line up with a set of input images
 * param: input_images -
 * param: membership_proofs_alignable -

--- a/src/seraphis_main/tx_builders_multisig.cpp
+++ b/src/seraphis_main/tx_builders_multisig.cpp
@@ -532,12 +532,14 @@ static bool try_make_v1_legacy_input_v1(const rct::key &tx_proposal_prefix,
         }
 
         // 3. assemble proof (will throw if partial sig assembly doesn't produce a valid proof)
-        LegacyRingSignatureV4 ring_signature;
+        rct::clsag clsag_rctlib;
         multisig::finalize_clsag_multisig_proof(input_proof_partial_sigs,
             referenced_enotes,
             masked_commitment,
-            ring_signature.clsag_proof);
+            clsag_rctlib);
 
+        LegacyRingSignatureV4 ring_signature;
+        ring_signature.clsag_proof = make_legacy_clsag_proof(clsag_rctlib);
         ring_signature.reference_set = std::move(reference_set);
 
         // 4. make legacy input

--- a/src/seraphis_main/tx_component_types.cpp
+++ b/src/seraphis_main/tx_component_types.cpp
@@ -167,9 +167,8 @@ void append_to_transcript(const SpEnoteImageV1 &container, SpTranscriptBuilder &
 void append_to_transcript(const SpMembershipProofV1 &container, SpTranscriptBuilder &transcript_inout)
 {
     transcript_inout.append("grootle_proof", container.grootle_proof);
-    transcript_inout.append("binned_reference_set", container.binned_reference_set);
-    transcript_inout.append("n", container.ref_set_decomp_n);
-    transcript_inout.append("m", container.ref_set_decomp_m);
+    transcript_inout.append("bin_loci", container.bin_loci);
+    transcript_inout.append("bin_rotation_factor", container.bin_rotation_factor);
 }
 //-------------------------------------------------------------------------------------------------------------------
 std::size_t sp_membership_proof_v1_size_bytes(const std::size_t n,
@@ -180,36 +179,16 @@ std::size_t sp_membership_proof_v1_size_bytes(const std::size_t n,
 
     return grootle_size_bytes(n, m) +
         (num_bin_members > 0
-            ? sp_binned_ref_set_v1_size_bytes(ref_set_size / num_bin_members)
-            : 0) +
-        4 * 2;  //decomposition parameters (assume these fit in 4 bytes each)
-}
-//-------------------------------------------------------------------------------------------------------------------
-std::size_t sp_membership_proof_v1_size_bytes_compact(const std::size_t n,
-    const std::size_t m,
-    const std::size_t num_bin_members)
-{
-    const std::size_t ref_set_size{math::uint_pow(n, m)};
-
-    return grootle_size_bytes(n, m) +
-        (num_bin_members > 0
-            ? sp_binned_ref_set_v1_size_bytes_compact(ref_set_size / num_bin_members)  //compact binned ref set
-            : 0);  //no decomposition parameters
+            ? sp_binned_ref_set_v1_size_bytes_compact(ref_set_size / num_bin_members)
+            : 0);
 }
 //-------------------------------------------------------------------------------------------------------------------
 std::size_t sp_membership_proof_v1_size_bytes(const SpMembershipProofV1 &proof)
 {
-    return sp_membership_proof_v1_size_bytes(proof.ref_set_decomp_n,
-        proof.ref_set_decomp_m,
-        proof.binned_reference_set.bin_config.num_bin_members);
+    return grootle_size_bytes(proof.grootle_proof) +
+        sp_binned_ref_set_v1_size_bytes_compact(proof.bin_loci.size());
 }
 //-------------------------------------------------------------------------------------------------------------------
-std::size_t sp_membership_proof_v1_size_bytes_compact(const SpMembershipProofV1 &proof)
-{
-    return sp_membership_proof_v1_size_bytes_compact(proof.ref_set_decomp_n,
-        proof.ref_set_decomp_m,
-        proof.binned_reference_set.bin_config.num_bin_members);
-}
 //-------------------------------------------------------------------------------------------------------------------
 void append_to_transcript(const SpImageProofV1 &container, SpTranscriptBuilder &transcript_inout)
 {

--- a/src/seraphis_main/tx_component_types.h
+++ b/src/seraphis_main/tx_component_types.h
@@ -139,25 +139,20 @@ struct SpMembershipProofV1 final
 {
     /// a grootle proof
     GrootleProof grootle_proof;
-    /// binned representation of ledger indices of enotes referenced by the proof
-    SpBinnedReferenceSetV1 binned_reference_set;
-    /// ref set size = n^m
-    std::size_t ref_set_decomp_n;
-    std::size_t ref_set_decomp_m;
+    /// loci of binned representation of ledger indices of enotes referenced by the proof
+    std::vector<std::uint64_t> bin_loci;
+    /// bin rotation factor (shared by all bins)
+    ref_set_bin_dimension_v1_t bin_rotation_factor;
 };
 inline const boost::string_ref container_name(const SpMembershipProofV1&) { return "SpMembershipProofV1"; }
 void append_to_transcript(const SpMembershipProofV1 &container, SpTranscriptBuilder &transcript_inout);
 
 /// get size in bytes
-/// - note: compact version excludes the decomposition parameters, and uses the compact size of the binned ref set
+/// - note: excludes the decomposition parameters, bin config, and generator seed
 std::size_t sp_membership_proof_v1_size_bytes(const std::size_t n,
     const std::size_t m,
     const std::size_t num_bin_members);
-std::size_t sp_membership_proof_v1_size_bytes_compact(const std::size_t n,
-    const std::size_t m,
-    const std::size_t num_bin_members);
 std::size_t sp_membership_proof_v1_size_bytes(const SpMembershipProofV1 &proof);
-std::size_t sp_membership_proof_v1_size_bytes_compact(const SpMembershipProofV1 &proof);
 
 ////
 // SpImageProofV1

--- a/src/seraphis_main/tx_component_types_legacy.cpp
+++ b/src/seraphis_main/tx_component_types_legacy.cpp
@@ -45,6 +45,24 @@
 namespace sp
 {
 //-------------------------------------------------------------------------------------------------------------------
+void append_to_transcript(const LegacyClsagProof &container, SpTranscriptBuilder &transcript_inout)
+{
+    transcript_inout.append("s", container.s);
+    transcript_inout.append("c1", container.c1);
+    transcript_inout.append("D", container.D);
+}
+//-------------------------------------------------------------------------------------------------------------------
+LegacyClsagProof make_legacy_clsag_proof(const rct::clsag &rctlib_clsag)
+{
+    return LegacyClsagProof{.s = rctlib_clsag.s, .c1 = rctlib_clsag.c1, .D = rctlib_clsag.D};
+}
+//-------------------------------------------------------------------------------------------------------------------
+rct::clsag convert_legacy_clsag_proof_to_rctlib(const LegacyClsagProof &clsag,
+    const crypto::key_image &key_image)
+{
+    return rct::clsag{.s = clsag.s, .c1 = clsag.c1, .I = rct::ki2rct(key_image), .D = clsag.D};
+}
+//-------------------------------------------------------------------------------------------------------------------
 void append_to_transcript(const LegacyEnoteImageV2 &container, SpTranscriptBuilder &transcript_inout)
 {
     transcript_inout.append("C_masked", container.masked_commitment);
@@ -53,7 +71,7 @@ void append_to_transcript(const LegacyEnoteImageV2 &container, SpTranscriptBuild
 //-------------------------------------------------------------------------------------------------------------------
 void append_to_transcript(const LegacyRingSignatureV4 &container, SpTranscriptBuilder &transcript_inout)
 {
-    append_clsag_to_transcript(container.clsag_proof, transcript_inout);
+    transcript_inout.append("clsag_proof", container.clsag_proof);
     transcript_inout.append("reference_set", container.reference_set);
 }
 //-------------------------------------------------------------------------------------------------------------------

--- a/src/seraphis_main/tx_component_types_legacy.h
+++ b/src/seraphis_main/tx_component_types_legacy.h
@@ -45,6 +45,25 @@ namespace sp { class SpTranscriptBuilder; }
 
 namespace sp
 {
+////
+// LegacyClsagProof
+// - NO key image here, just proof elements
+///
+struct LegacyClsagProof
+{
+    /// scalars
+    rct::keyV s;
+    rct::key c1;
+    /// commitment key image
+    rct::key D;
+};
+inline const boost::string_ref container_name(const LegacyClsagProof&) { return "LegacyClsagProof"; }
+void append_to_transcript(const LegacyClsagProof &container, SpTranscriptBuilder &transcript_inout);
+
+/// convert back and forth between LegacyClsagProof and rct::clsag
+LegacyClsagProof make_legacy_clsag_proof(const rct::clsag &rctlib_clsag);
+rct::clsag convert_legacy_clsag_proof_to_rctlib(const LegacyClsagProof &clsag,
+    const crypto::key_image &key_image);
 
 ////
 // LegacyEnoteImageV1: not used in seraphis
@@ -91,7 +110,7 @@ inline std::size_t legacy_enote_image_v2_size_bytes() { return 32 + 32; }
 struct LegacyRingSignatureV4 final
 {
     /// a clsag proof
-    rct::clsag clsag_proof;
+    LegacyClsagProof clsag_proof;
     /// on-chain indices of the proof's ring members
     std::vector<std::uint64_t> reference_set;
 };

--- a/src/seraphis_main/tx_validation_context.h
+++ b/src/seraphis_main/tx_validation_context.h
@@ -33,6 +33,8 @@
 //local headers
 #include "crypto/crypto.h"
 #include "ringct/rctTypes.h"
+#include "txtype_base.h"
+#include "tx_validators.h"
 
 //third party headers
 
@@ -56,6 +58,13 @@ public:
     TxValidationContext& operator=(TxValidationContext&&) = delete;
 
 //member functions
+    /**
+     * brief: get_sp_ref_set_config - given tx version, return refset config to validate tx against
+     * param: txver -
+     * return: SemanticConfigSpRefSetV1 object (ref) which should be used to validate the transaction
+     * note: returned reference should be valid for the lifetime of the validation context
+    */
+    virtual const SemanticConfigSpRefSetV1& get_sp_ref_set_config(const tx_version_t txver) const = 0;
     /**
     * brief: cryptonote_key_image_exists - checks if a cryptonote-style key image exists in the validation context
     * param: key_image -

--- a/src/seraphis_main/tx_validators.cpp
+++ b/src/seraphis_main/tx_validators.cpp
@@ -200,7 +200,7 @@ bool validate_sp_semantics_sp_reference_sets_v1(const SemanticConfigSpRefSetV1 &
     const std::size_t num_bin_loci = sp_membership_proofs[0].bin_loci.size();
 
     // Check that the number of bin loci evenly divides the total reference set size
-    if (ref_set_size % num_bin_loci != 0)
+    if ((num_bin_loci == 0) || (ref_set_size % num_bin_loci != 0))
         return false;
 
     // check seraphis membership proofs

--- a/src/seraphis_main/tx_validators.h
+++ b/src/seraphis_main/tx_validators.h
@@ -80,14 +80,10 @@ struct SemanticConfigLegacyRefSetV1 final
 /// semantic validation config: seraphis reference sets
 struct SemanticConfigSpRefSetV1 final
 {
-    std::size_t decomp_n_min;
-    std::size_t decomp_n_max;
-    std::size_t decomp_m_min;
-    std::size_t decomp_m_max;
-    std::size_t bin_radius_min;
-    std::size_t bin_radius_max;
-    std::size_t num_bin_members_min;
-    std::size_t num_bin_members_max;
+    std::size_t decomp_n;
+    std::size_t decomp_m;
+    std::size_t bin_radius;
+    std::size_t num_bin_members;
 };
 
 /**
@@ -288,11 +284,13 @@ bool validate_sp_composition_proofs_v1(const std::vector<SpImageProofV1> &sp_ima
 *   - get verification data for grootle proofs (membership proofs)
 * param: membership_proofs -
 * param: input_images -
+* param: sp_ref_set_config -
 * param: tx_validation_context -
 * outparam: validation_data_out -
 */
 bool try_get_sp_membership_proofs_v1_validation_data(const std::vector<const SpMembershipProofV1*> &membership_proofs,
     const std::vector<const SpEnoteImageCore*> &input_images,
+    const SemanticConfigSpRefSetV1 &sp_ref_set_config,
     const TxValidationContext &tx_validation_context,
     std::list<SpMultiexpBuilder> &validation_data_out);
 

--- a/src/seraphis_main/txtype_base.cpp
+++ b/src/seraphis_main/txtype_base.cpp
@@ -62,6 +62,9 @@ static bool validate_txs_impl(const std::vector<const SpTxType*> &txs, const TxV
             if (!validate_tx_semantics(*tx))
                 return false;
 
+            if (!validate_tx_semantics_sp_ref_set(*tx, tx_validation_context))
+                return false;
+
             if (!validate_tx_key_images(*tx, tx_validation_context))
                 return false;
 

--- a/src/seraphis_main/txtype_base.h
+++ b/src/seraphis_main/txtype_base.h
@@ -66,6 +66,8 @@ unsigned char tx_structure_version();
 template <typename SpTxType>
 bool validate_tx_semantics(const SpTxType &tx);
 template <typename SpTxType>
+bool validate_tx_semantics_sp_ref_set(const SpTxType &tx, const TxValidationContext &tx_validation_context);
+template <typename SpTxType>
 bool validate_tx_key_images(const SpTxType &tx, const TxValidationContext &tx_validation_context);
 template <typename SpTxType>
 bool validate_tx_amount_balance(const SpTxType &tx);

--- a/src/seraphis_main/txtype_coinbase_v1.cpp
+++ b/src/seraphis_main/txtype_coinbase_v1.cpp
@@ -215,6 +215,12 @@ bool validate_tx_semantics<SpTxCoinbaseV1>(const SpTxCoinbaseV1 &tx)
 }
 //-------------------------------------------------------------------------------------------------------------------
 template <>
+bool validate_tx_semantics_sp_ref_set<SpTxCoinbaseV1>(const SpTxCoinbaseV1&, const TxValidationContext&)
+{
+    return true;
+}
+//-------------------------------------------------------------------------------------------------------------------
+template <>
 bool validate_tx_key_images<SpTxCoinbaseV1>(const SpTxCoinbaseV1&, const TxValidationContext&)
 {
     // coinbase txs have no key images

--- a/src/seraphis_main/txtype_coinbase_v1.h
+++ b/src/seraphis_main/txtype_coinbase_v1.h
@@ -145,6 +145,9 @@ inline tx_version_t tx_version_from(const SpTxCoinbaseV1::SemanticRulesVersion t
 template <>
 bool validate_tx_semantics<SpTxCoinbaseV1>(const SpTxCoinbaseV1 &tx);
 template <>
+bool validate_tx_semantics_sp_ref_set<SpTxCoinbaseV1>(const SpTxCoinbaseV1 &tx,
+    const TxValidationContext &tx_validation_context);
+template <>
 bool validate_tx_key_images<SpTxCoinbaseV1>(const SpTxCoinbaseV1&, const TxValidationContext&);
 template <>
 bool validate_tx_amount_balance<SpTxCoinbaseV1>(const SpTxCoinbaseV1 &tx);

--- a/src/seraphis_main/txtype_squashed_v1.h
+++ b/src/seraphis_main/txtype_squashed_v1.h
@@ -202,11 +202,11 @@ SemanticConfigComponentCountsV1 semantic_config_component_counts_v1(
 SemanticConfigLegacyRefSetV1 semantic_config_legacy_ref_sets_v1(
     const SpTxSquashedV1::SemanticRulesVersion tx_semantic_rules_version);
 /**
-* brief: semantic_config_sp_ref_sets_v1 - seraphis reference set configuration for a given semantics rule version
+* brief: static_semantic_config_sp_ref_sets_v1 - seraphis reference set configuration for a given semantics rule version
 * param: tx_semantic_rules_version -
 * return: allowed reference set configuration for the given semantics rules version
 */
-SemanticConfigSpRefSetV1 semantic_config_sp_ref_sets_v1(
+SemanticConfigSpRefSetV1 static_semantic_config_sp_ref_sets_v1(
     const SpTxSquashedV1::SemanticRulesVersion tx_semantic_rules_version);
 
 
@@ -232,6 +232,9 @@ inline tx_version_t tx_version_from(const SpTxSquashedV1::SemanticRulesVersion t
 /// transaction validators
 template <>
 bool validate_tx_semantics<SpTxSquashedV1>(const SpTxSquashedV1 &tx);
+template <>
+bool validate_tx_semantics_sp_ref_set<SpTxSquashedV1>(const SpTxSquashedV1 &tx,
+    const TxValidationContext &tx_validation_context);
 template <>
 bool validate_tx_key_images<SpTxSquashedV1>(const SpTxSquashedV1 &tx, const TxValidationContext &tx_validation_context);
 template <>

--- a/src/seraphis_mocks/mock_send_receive.cpp
+++ b/src/seraphis_mocks/mock_send_receive.cpp
@@ -158,7 +158,7 @@ void send_sp_coinbase_amounts_to_user(const std::vector<rct::xmr_amount> &coinba
         coinbase_tx);
 
     // 3. validate the coinbase tx
-    const TxValidationContextMock tx_validation_context{ledger_context_inout};
+    const TxValidationContextMock tx_validation_context{ledger_context_inout, {}};
     CHECK_AND_ASSERT_THROW_MES(validate_tx(coinbase_tx, tx_validation_context),
         "send sp coinbase amounts to user (mock): failed to validate coinbase tx.");
 
@@ -198,7 +198,7 @@ void send_sp_coinbase_amounts_to_users(const std::vector<std::vector<rct::xmr_am
         coinbase_tx);
 
     // 3. validate the coinbase tx
-    const TxValidationContextMock tx_validation_context{ledger_context_inout};
+    const TxValidationContextMock tx_validation_context{ledger_context_inout, {}};
     CHECK_AND_ASSERT_THROW_MES(validate_tx(coinbase_tx, tx_validation_context),
         "send sp coinbase amounts to user (mock): failed to validate coinbase tx.");
 
@@ -383,7 +383,14 @@ void transfer_funds_single_mock_v1_unconfirmed_sp_only(const jamtis::mocks::jamt
         single_tx);
 
     // 2. validate and submit to the mock ledger
-    const TxValidationContextMock tx_validation_context{ledger_context_inout};
+    const TxValidationContextMock tx_validation_context{ledger_context_inout,
+        SemanticConfigSpRefSetV1{
+            .decomp_n = ref_set_decomp_n,
+            .decomp_m = ref_set_decomp_m,
+            .bin_radius = bin_config.bin_radius,
+            .num_bin_members = bin_config.num_bin_members
+        }
+    };
     CHECK_AND_ASSERT_THROW_MES(validate_tx(single_tx, tx_validation_context),
         "transfer funds single mock unconfirmed: validating tx failed.");
     CHECK_AND_ASSERT_THROW_MES(ledger_context_inout.try_add_unconfirmed_tx_v1(single_tx),
@@ -420,7 +427,14 @@ void transfer_funds_single_mock_v1_unconfirmed(const legacy_mock_keys &local_use
         single_tx);
 
     // 2. validate and submit to the mock ledger
-    const TxValidationContextMock tx_validation_context{ledger_context_inout};
+    const TxValidationContextMock tx_validation_context{ledger_context_inout,
+        SemanticConfigSpRefSetV1{
+            .decomp_n = ref_set_decomp_n,
+            .decomp_m = ref_set_decomp_m,
+            .bin_radius = bin_config.bin_radius,
+            .num_bin_members = bin_config.num_bin_members
+        }
+    };
     CHECK_AND_ASSERT_THROW_MES(validate_tx(single_tx, tx_validation_context),
         "transfer funds single mock unconfirmed sp only: validating tx failed.");
     CHECK_AND_ASSERT_THROW_MES(ledger_context_inout.try_add_unconfirmed_tx_v1(single_tx),
@@ -457,7 +471,14 @@ void transfer_funds_single_mock_v1(const legacy_mock_keys &local_user_legacy_key
         single_tx);
 
     // 2, validate and submit to the mock ledger
-    const TxValidationContextMock tx_validation_context{ledger_context_inout};
+    const TxValidationContextMock tx_validation_context{ledger_context_inout,
+        SemanticConfigSpRefSetV1{
+            .decomp_n = ref_set_decomp_n,
+            .decomp_m = ref_set_decomp_m,
+            .bin_radius = bin_config.bin_radius,
+            .num_bin_members = bin_config.num_bin_members
+        }
+    };
     CHECK_AND_ASSERT_THROW_MES(validate_tx(single_tx, tx_validation_context),
         "transfer funds single mock: validating tx failed.");
     CHECK_AND_ASSERT_THROW_MES(try_add_tx_to_ledger(single_tx, ledger_context_inout),

--- a/src/seraphis_mocks/tx_validation_context_mock.h
+++ b/src/seraphis_mocks/tx_validation_context_mock.h
@@ -55,8 +55,10 @@ class TxValidationContextMock final : public TxValidationContext
 {
 public:
 //constructors
-    TxValidationContextMock(const MockLedgerContext &mock_ledger_context) :
-        m_mock_ledger_context{mock_ledger_context}
+    TxValidationContextMock(const MockLedgerContext &mock_ledger_context,
+        const SemanticConfigSpRefSetV1 &sp_ref_set_config) :
+        m_mock_ledger_context{mock_ledger_context},
+        m_current_sp_ref_set_config{sp_ref_set_config}
     {}
 
 //overloaded operators
@@ -64,6 +66,15 @@ public:
     TxValidationContextMock& operator=(TxValidationContextMock&&) = delete;
 
 //member functions
+    /**
+     * brief: get_sp_ref_set_config - given tx version, return refset config to validate tx against
+     * param: txver -
+     * return: SemanticConfigSpRefSetV1 object which should be used to validate the transaction
+    */
+    virtual const SemanticConfigSpRefSetV1& get_sp_ref_set_config(const tx_version_t) const override
+    {
+        return m_current_sp_ref_set_config;
+    }
     /**
     * brief: cryptonote_key_image_exists - checks if a cryptonote key image exists in the mock ledger
     * param: key_image -
@@ -106,6 +117,7 @@ public:
 //member variables
 private:
     const MockLedgerContext &m_mock_ledger_context;
+    const SemanticConfigSpRefSetV1 m_current_sp_ref_set_config;
 };
 
 } //namespace mocks

--- a/tests/performance_tests/seraphis_tx.h
+++ b/tests/performance_tests/seraphis_tx.h
@@ -321,6 +321,12 @@ public:
                 tx_params.sp_input_amounts = std::move(sp_input_amounts);
                 tx_params.output_amounts = std::move(output_amounts);
                 tx_params.discretized_fee = sp::discretize_fee(0);
+                m_sp_ref_set_config = sp::SemanticConfigSpRefSetV1{
+                        .decomp_n = params.n,
+                        .decomp_m = params.m,
+                        .bin_radius = sp::math::uint_pow(params.n, params.m) / 2,
+                        .num_bin_members = sp::math::uint_pow(params.n, params.m / 2)
+                    };
 
                 // make tx
                 m_txs.emplace_back();
@@ -379,7 +385,10 @@ public:
     {
         try
         {
-            const sp::mocks::TxValidationContextMock tx_validation_context{*m_ledger_contex};
+            const sp::mocks::TxValidationContextMock tx_validation_context{
+                    *m_ledger_contex,
+                    m_sp_ref_set_config
+                };
             return sp::validate_txs(m_tx_ptrs, tx_validation_context);
         }
         catch (...)
@@ -391,5 +400,6 @@ public:
 private:
     std::vector<SpTxType> m_txs;
     std::vector<const SpTxType*> m_tx_ptrs;
+    sp::SemanticConfigSpRefSetV1 m_sp_ref_set_config;
     std::shared_ptr<sp::mocks::MockLedgerContext> m_ledger_contex;
 };

--- a/tests/unit_tests/seraphis_basic.cpp
+++ b/tests/unit_tests/seraphis_basic.cpp
@@ -1272,14 +1272,21 @@ TEST(seraphis_basic, txtype_squashed_v1)
     txs.reserve(num_txs);
     tx_ptrs.reserve(num_txs);
 
+    const SemanticConfigSpRefSetV1 sp_ref_set_config{
+        .decomp_n = 2,
+        .decomp_m = 2,
+        .bin_radius = 1,
+        .num_bin_members = 2
+    };
+
     for (std::size_t tx_index{0}; tx_index < num_txs; ++tx_index)
     {
         make_sp_txtype_squashed_v1(2,
-            2,
-            2,
+            sp_ref_set_config.decomp_n,
+            sp_ref_set_config.decomp_m,
             SpBinnedReferenceSetConfigV1{
-                .bin_radius = 1,
-                .num_bin_members = 2
+                .bin_radius = static_cast<ref_set_bin_dimension_v1_t>(sp_ref_set_config.bin_radius),
+                .num_bin_members = static_cast<ref_set_bin_dimension_v1_t>(sp_ref_set_config.num_bin_members)
             },
             3,
             in_legacy_amounts,
@@ -1292,7 +1299,7 @@ TEST(seraphis_basic, txtype_squashed_v1)
         tx_ptrs.push_back(&(txs.back()));
     }
 
-    const TxValidationContextMock tx_validation_context{ledger_context};
+    const TxValidationContextMock tx_validation_context{ledger_context, sp_ref_set_config};
 
     EXPECT_TRUE(validate_txs(tx_ptrs, tx_validation_context));
 

--- a/tests/unit_tests/seraphis_knowledge_proofs.cpp
+++ b/tests/unit_tests/seraphis_knowledge_proofs.cpp
@@ -419,6 +419,13 @@ TEST(seraphis_knowledge_proofs, reserve_proof)
             .bin_radius = 1,
             .num_bin_members = 2
         };
+    
+    const SemanticConfigSpRefSetV1 sp_ref_set_config{
+            .decomp_n = ref_set_decomp_n,
+            .decomp_m = ref_set_decomp_m,
+            .bin_radius = bin_config.bin_radius,
+            .num_bin_members = bin_config.num_bin_members
+        };
 
     /// mock ledger context for this test
     MockLedgerContext ledger_context{0, 10000};
@@ -508,7 +515,7 @@ TEST(seraphis_knowledge_proofs, reserve_proof)
         {SpEnoteSpentStatus::SPENT_ONCHAIN}) == 9);
 
     // make and validate their reserve proofs
-    const TxValidationContextMock tx_validation_context{ledger_context};
+    const TxValidationContextMock tx_validation_context{ledger_context, sp_ref_set_config};
 
     reserve_proof_helper(tx_validation_context, user_keys_A, enote_store_A, 29);
     reserve_proof_helper(tx_validation_context, user_keys_B, enote_store_B, 9);

--- a/tests/unit_tests/seraphis_multisig.cpp
+++ b/tests/unit_tests/seraphis_multisig.cpp
@@ -379,6 +379,13 @@ static void seraphis_multisig_tx_v1_test(const std::uint32_t threshold,
             .num_bin_members = num_bin_members
         };
 
+    const SemanticConfigSpRefSetV1 sp_ref_set_config{
+        .decomp_n = ref_set_decomp_n,
+        .decomp_m = ref_set_decomp_m,
+        .bin_radius = bin_radius,
+        .num_bin_members = num_bin_members
+    };
+
     // global
     MockLedgerContext ledger_context{0, 10000};
 
@@ -789,7 +796,7 @@ static void seraphis_multisig_tx_v1_test(const std::uint32_t threshold,
     //ASSERT_TRUE(completed_tx.tx_fee == tx_fee_calculator.compute_fee(fee_per_tx_weight, completed_tx));
 
     // g) verify tx
-    const TxValidationContextMock tx_validation_context{ledger_context};
+    const TxValidationContextMock tx_validation_context{ledger_context, sp_ref_set_config};
     ASSERT_NO_THROW(ASSERT_TRUE(validate_tx(completed_tx, tx_validation_context)));
 
     // h) add tx to mock ledger

--- a/tests/unit_tests/seraphis_serialization.cpp
+++ b/tests/unit_tests/seraphis_serialization.cpp
@@ -95,7 +95,7 @@ TEST(seraphis_serialization_demo, seraphis_squashed_empty)
 
     // recover the tx
     SpTxSquashedV1 recovered_tx;
-    EXPECT_NO_THROW(sp::serialization::recover_sp_tx_squashed_v1(serializable_tx_recovered, {}, 0, 0, recovered_tx));
+    EXPECT_NO_THROW(sp::serialization::recover_sp_tx_squashed_v1(serializable_tx_recovered, recovered_tx));
 
     // check that the original tx was recovered
     rct::key original_tx_id;
@@ -112,7 +112,7 @@ TEST(seraphis_serialization_demo, seraphis_coinbase_standard)
 {
     // ledger context
     MockLedgerContext ledger_context{0, 10000};
-    const TxValidationContextMock tx_validation_context{ledger_context};
+    const TxValidationContextMock tx_validation_context{ledger_context, {}};
 
     // make a tx
     SpTxCoinbaseV1 tx;
@@ -165,10 +165,17 @@ TEST(seraphis_serialization_demo, seraphis_squashed_standard)
     tx_params.sp_input_amounts = {2, 3};
     tx_params.output_amounts = {3};
     tx_params.discretized_fee = discretize_fee(3);
+    
+    const SemanticConfigSpRefSetV1 sp_ref_set_config{
+            .decomp_n = tx_params.ref_set_decomp_n,
+            .decomp_m = tx_params.ref_set_decomp_m,
+            .bin_radius = tx_params.bin_config.bin_radius,
+            .num_bin_members = tx_params.bin_config.num_bin_members,
+        };
 
     // ledger context
     MockLedgerContext ledger_context{0, 10000};
-    const TxValidationContextMock tx_validation_context{ledger_context};
+    const TxValidationContextMock tx_validation_context{ledger_context, sp_ref_set_config};
 
     // make a tx
     SpTxSquashedV1 tx;
@@ -192,9 +199,6 @@ TEST(seraphis_serialization_demo, seraphis_squashed_standard)
     // recover the tx
     SpTxSquashedV1 recovered_tx;
     EXPECT_NO_THROW(sp::serialization::recover_sp_tx_squashed_v1(serializable_tx_recovered,
-        tx_params.bin_config,
-        tx_params.ref_set_decomp_n,
-        tx_params.ref_set_decomp_m,
         recovered_tx));
 
     // check the tx was recovered

--- a/tests/unit_tests/seraphis_tx.cpp
+++ b/tests/unit_tests/seraphis_tx.cpp
@@ -81,7 +81,14 @@ static void run_mock_tx_test(const std::size_t legacy_ring_size,
     const bool test_double_spend,
     MockLedgerContext &ledger_context_inout)
 {
-    const TxValidationContextMock tx_validation_context{ledger_context_inout};
+    const SemanticConfigSpRefSetV1 sp_ref_set_config{
+            .decomp_n = ref_set_decomp_n,
+            .decomp_m = ref_set_decomp_m,
+            .bin_radius = bin_config.bin_radius,
+            .num_bin_members = bin_config.num_bin_members
+        };
+
+    const TxValidationContextMock tx_validation_context{ledger_context_inout, sp_ref_set_config};
 
     try
     {
@@ -161,12 +168,22 @@ template <typename SpTxType>
 static void run_mock_tx_test_batch(const std::vector<SpTxGenData> &gen_data)
 {
     MockLedgerContext ledger_context{0, 10000};
-    const TxValidationContextMock tx_validation_context{ledger_context};
     std::vector<SpTxType> txs_to_verify;
     std::vector<const SpTxType*> txs_to_verify_ptrs;
     txs_to_verify.reserve(gen_data.size() * 2);
     txs_to_verify_ptrs.reserve(gen_data.size() * 2);
     TestType expected_result = TestType::ExpectTrue;
+
+    // Batchable txs must share same seraphis reference set config, otherwise validation fails later
+    ASSERT_NE(0, gen_data.size());
+    const SemanticConfigSpRefSetV1 sp_ref_set_config{
+            .decomp_n = gen_data[0].ref_set_decomp_n,
+            .decomp_m = gen_data[0].ref_set_decomp_m,
+            .bin_radius = gen_data[0].bin_config.bin_radius,
+            .num_bin_members = gen_data[0].bin_config.num_bin_members
+        };
+    
+    const TxValidationContextMock tx_validation_context{ledger_context, sp_ref_set_config};
 
     for (const SpTxGenData &gen : gen_data)
     {
@@ -270,7 +287,14 @@ static void run_mock_tx_test_cached(const std::size_t legacy_ring_size,
     const bool test_double_spend,
     MockLedgerContext &ledger_context_inout)
 {
-    const TxValidationContextMock tx_validation_context{ledger_context_inout};
+    const SemanticConfigSpRefSetV1 sp_ref_set_config{
+            .decomp_n = ref_set_decomp_n,
+            .decomp_m = ref_set_decomp_m,
+            .bin_radius = bin_config.bin_radius,
+            .num_bin_members = bin_config.num_bin_members
+        };
+
+    const TxValidationContextMock tx_validation_context{ledger_context_inout, sp_ref_set_config};
 
     try
     {


### PR DESCRIPTION
Use free functions to do serialization in-place. Simplifies code, reduces binary size, and reduces copying.