### PR TITLE
SpTxCoinbaseV1: remove block_reward field

### DIFF
--- a/src/seraphis_impl/serialization_demo_types.h
+++ b/src/seraphis_impl/serialization_demo_types.h
@@ -363,8 +363,6 @@ struct ser_SpTxCoinbaseV1 final
 
     /// height of the block whose block reward this coinbase tx disperses
     std::uint64_t block_height;
-    /// block reward dispersed by this coinbase tx
-    rct::xmr_amount block_reward;
     /// tx outputs (new enotes)
     std::vector<ser_SpCoinbaseEnoteV1> outputs;
     /// supplemental data for tx
@@ -373,7 +371,6 @@ struct ser_SpTxCoinbaseV1 final
     BEGIN_SERIALIZE()
         VARINT_FIELD(tx_semantic_rules_version)
         VARINT_FIELD(block_height)
-        VARINT_FIELD(block_reward)
         FIELD(outputs)
         FIELD(tx_supplement)
     END_SERIALIZE()

--- a/src/seraphis_impl/serialization_demo_utils.cpp
+++ b/src/seraphis_impl/serialization_demo_utils.cpp
@@ -364,9 +364,6 @@ void make_serializable_sp_tx_coinbase_v1(const SpTxCoinbaseV1 &tx, ser_SpTxCoinb
     // block height
     serializable_tx_out.block_height = tx.block_height;
 
-    // block reward
-    serializable_tx_out.block_reward = tx.block_reward;
-
     // tx outputs (new enotes)
     copy_array(&make_serializable_sp_coinbase_enote_v1, tx.outputs, serializable_tx_out.outputs);
 
@@ -618,9 +615,6 @@ void recover_sp_tx_coinbase_v1(ser_SpTxCoinbaseV1 &serializable_tx_in, SpTxCoinb
 
     // block height
     tx_out.block_height = serializable_tx_in.block_height;
-
-    // block reward
-    tx_out.block_reward = serializable_tx_in.block_reward;
 
     // tx outputs (new enotes)
     relay_array(&recover_sp_coinbase_enote_v1, serializable_tx_in.outputs, tx_out.outputs);

--- a/src/seraphis_main/tx_builder_types.h
+++ b/src/seraphis_main/tx_builder_types.h
@@ -158,8 +158,6 @@ struct SpCoinbaseTxProposalV1 final
 {
     /// block height
     std::uint64_t block_height;
-    /// block reward
-    rct::xmr_amount block_reward;
     /// outputs (SORTED)
     std::vector<jamtis::JamtisPaymentProposalV1> normal_payment_proposals;
     /// partial memo

--- a/src/seraphis_main/tx_builders_mixed.cpp
+++ b/src/seraphis_main/tx_builders_mixed.cpp
@@ -775,7 +775,7 @@ void check_v1_coinbase_tx_proposal_semantics_v1(const SpCoinbaseTxProposalV1 &tx
     check_v1_tx_supplement_semantics_v1(tx_supplement, output_enotes.size());
 
     // 6. check balance
-    CHECK_AND_ASSERT_THROW_MES(validate_sp_coinbase_amount_balance_v1(tx_proposal.block_reward, output_enotes),
+    CHECK_AND_ASSERT_THROW_MES(validate_sp_coinbase_amount_overflow_v1(output_enotes),
         "Semantics check coinbase tx proposal v1: outputs do not balance the block reward.");
 }
 //-------------------------------------------------------------------------------------------------------------------
@@ -821,14 +821,12 @@ void check_v1_tx_proposal_semantics_v1(const SpTxProposalV1 &tx_proposal,
 }
 //-------------------------------------------------------------------------------------------------------------------
 void make_v1_coinbase_tx_proposal_v1(const std::uint64_t block_height,
-    const rct::xmr_amount block_reward,
     std::vector<jamtis::JamtisPaymentProposalV1> normal_payment_proposals,
     std::vector<ExtraFieldElement> additional_memo_elements,
     SpCoinbaseTxProposalV1 &tx_proposal_out)
 {
     // set fields
     tx_proposal_out.block_height             = block_height;
-    tx_proposal_out.block_reward             = block_reward;
     tx_proposal_out.normal_payment_proposals = std::move(normal_payment_proposals);
     make_tx_extra(std::move(additional_memo_elements), tx_proposal_out.partial_memo);
 }

--- a/src/seraphis_main/tx_builders_mixed.h
+++ b/src/seraphis_main/tx_builders_mixed.h
@@ -153,13 +153,11 @@ void check_v1_tx_proposal_semantics_v1(const SpTxProposalV1 &tx_proposal,
 /**
 * brief: make_v1_coinbase_tx_proposal_v1 - make v1 coinbase tx proposal
 * param: block_height -
-* param: block_reward -
 * param: normal_payment_proposals -
 * param: additional_memo_elements -
 * outparam: tx_proposal_out -
 */
 void make_v1_coinbase_tx_proposal_v1(const std::uint64_t block_height,
-    const rct::xmr_amount block_reward,
     std::vector<jamtis::JamtisPaymentProposalV1> normal_payment_proposals,
     std::vector<ExtraFieldElement> additional_memo_elements,
     SpCoinbaseTxProposalV1 &tx_proposal_out);

--- a/src/seraphis_main/tx_validators.cpp
+++ b/src/seraphis_main/tx_validators.cpp
@@ -410,7 +410,7 @@ bool validate_sp_key_images_v1(const std::vector<LegacyEnoteImageV2> &legacy_inp
 //-------------------------------------------------------------------------------------------------------------------
 bool validate_sp_coinbase_amount_overflow_v1(const std::vector<SpCoinbaseEnoteV1> &outputs)
 {
-    // add together output amounts (use uint128_t to prevent malicious overflow)
+    // expect the output sum doesn't overflow
     boost::multiprecision::uint128_t output_amount_sum{0};
 
     for (const SpCoinbaseEnoteV1 &output : outputs)

--- a/src/seraphis_main/tx_validators.cpp
+++ b/src/seraphis_main/tx_validators.cpp
@@ -408,8 +408,7 @@ bool validate_sp_key_images_v1(const std::vector<LegacyEnoteImageV2> &legacy_inp
     return true;
 }
 //-------------------------------------------------------------------------------------------------------------------
-bool validate_sp_coinbase_amount_balance_v1(const rct::xmr_amount block_reward,
-    const std::vector<SpCoinbaseEnoteV1> &outputs)
+bool validate_sp_coinbase_amount_overflow_v1(const std::vector<SpCoinbaseEnoteV1> &outputs)
 {
     // add together output amounts (use uint128_t to prevent malicious overflow)
     boost::multiprecision::uint128_t output_amount_sum{0};
@@ -417,8 +416,7 @@ bool validate_sp_coinbase_amount_balance_v1(const rct::xmr_amount block_reward,
     for (const SpCoinbaseEnoteV1 &output : outputs)
         output_amount_sum += output.core.amount;
 
-    // expect output amount equals coinbase block reward
-    if (block_reward != output_amount_sum)
+    if (output_amount_sum > std::numeric_limits<rct::xmr_amount>::max())
         return false;
 
     return true;

--- a/src/seraphis_main/tx_validators.h
+++ b/src/seraphis_main/tx_validators.h
@@ -235,14 +235,11 @@ bool validate_sp_key_images_v1(const std::vector<LegacyEnoteImageV2> &legacy_inp
     const std::vector<SpEnoteImageV1> &sp_input_images,
     const TxValidationContext &tx_validation_context);
 /**
-* brief: validate_sp_coinbase_amount_balance_v1 - check that amounts balance in the coinbase tx (block reward == outputs)
-*   - check block_reward == sum(output amounts)
-* param: block_reward -
+* brief: validate_sp_coinbase_amount_overflow_v1 - check that coinbase amount sum doesn't overflow
 * param: outputs -
 * return: true/false on validation result
 */
-bool validate_sp_coinbase_amount_balance_v1(const rct::xmr_amount block_reward,
-    const std::vector<SpCoinbaseEnoteV1> &outputs);
+bool validate_sp_coinbase_amount_overflow_v1(const std::vector<SpCoinbaseEnoteV1> &outputs);
 /**
 * brief: validate_sp_amount_balance_v1 - check that amounts balance in the tx (inputs == outputs)
 *   - check sum(input image masked commitments) == sum(output commitments) + fee*H + remainder*G

--- a/src/seraphis_main/txtype_coinbase_v1.h
+++ b/src/seraphis_main/txtype_coinbase_v1.h
@@ -73,8 +73,6 @@ struct SpTxCoinbaseV1 final
 
     /// height of the block whose block reward this coinbase tx disperses
     std::uint64_t block_height;
-    /// block reward dispersed by this coinbase tx
-    rct::xmr_amount block_reward;
     /// tx outputs (new coinbase enotes)
     std::vector<SpCoinbaseEnoteV1> outputs;
     /// supplemental data for tx
@@ -103,7 +101,6 @@ void get_sp_tx_coinbase_v1_txid(const SpTxCoinbaseV1 &tx, rct::key &tx_id_out);
 */
 void make_seraphis_tx_coinbase_v1(const SpTxCoinbaseV1::SemanticRulesVersion semantic_rules_version,
     const std::uint64_t block_height,
-    const rct::xmr_amount block_reward,
     std::vector<SpCoinbaseEnoteV1> outputs,
     SpTxSupplementV1 tx_supplement,
     SpTxCoinbaseV1 &tx_out);
@@ -112,7 +109,6 @@ void make_seraphis_tx_coinbase_v1(const SpTxCoinbaseV1::SemanticRulesVersion sem
     SpTxCoinbaseV1 &tx_out);
 void make_seraphis_tx_coinbase_v1(const SpTxCoinbaseV1::SemanticRulesVersion semantic_rules_version,
     const std::uint64_t block_height,
-    const rct::xmr_amount block_reward,
     std::vector<jamtis::JamtisPaymentProposalV1> normal_payment_proposals,
     std::vector<ExtraFieldElement> additional_memo_elements,
     SpTxCoinbaseV1 &tx_out);

--- a/src/seraphis_mocks/make_mock_tx.cpp
+++ b/src/seraphis_mocks/make_mock_tx.cpp
@@ -64,12 +64,15 @@ namespace sp
 namespace mocks
 {
 //-------------------------------------------------------------------------------------------------------------------
-void make_mock_coinbase_tx(const SpTxParamPackV1 &params,
-    const std::vector<rct::xmr_amount> &out_amounts,
+template <>
+void make_mock_tx<SpTxCoinbaseV1>(const SpTxParamPackV1 &params,
     MockLedgerContext &ledger_context_inout,
     SpTxCoinbaseV1 &tx_out)
 {
-    CHECK_AND_ASSERT_THROW_MES(out_amounts.size() > 0, "SpTxCoinbaseV1: tried to make mock tx without any outputs.");
+    const std::vector<rct::xmr_amount> &out_amounts = params.output_amounts;
+
+    CHECK_AND_ASSERT_THROW_MES(out_amounts.size() > 0,
+        "SpTxCoinbaseV1: tried to make mock tx without any outputs.");
 
     // 1. mock semantics version
     const SpTxCoinbaseV1::SemanticRulesVersion semantic_rules_version{SpTxCoinbaseV1::SemanticRulesVersion::MOCK};
@@ -106,26 +109,15 @@ void make_mock_coinbase_tx(const SpTxParamPackV1 &params,
 }
 //-------------------------------------------------------------------------------------------------------------------
 template <>
-void make_mock_tx<SpTxCoinbaseV1>(const SpTxParamPackV1 &params,
-    const std::vector<rct::xmr_amount>&,
-    const std::vector<rct::xmr_amount>&,
-    const std::vector<rct::xmr_amount> &out_amounts,
-    const DiscretizedFee,
-    MockLedgerContext &ledger_context_inout,
-    SpTxCoinbaseV1 &tx_out)
-{
-    return make_mock_coinbase_tx(params, out_amounts, ledger_context_inout, tx_out);
-}
-//-------------------------------------------------------------------------------------------------------------------
-template <>
 void make_mock_tx<SpTxSquashedV1>(const SpTxParamPackV1 &params,
-    const std::vector<rct::xmr_amount> &legacy_in_amounts,
-    const std::vector<rct::xmr_amount> &sp_in_amounts,
-    const std::vector<rct::xmr_amount> &out_amounts,
-    const DiscretizedFee discretized_transaction_fee,
     MockLedgerContext &ledger_context_inout,
     SpTxSquashedV1 &tx_out)
 {
+    const std::vector<rct::xmr_amount> &legacy_in_amounts = params.legacy_input_amounts;
+    const std::vector<rct::xmr_amount> &sp_in_amounts = params.sp_input_amounts;
+    const std::vector<rct::xmr_amount> &out_amounts = params.output_amounts;
+    const DiscretizedFee &discretized_transaction_fee = params.discretized_fee;
+
     CHECK_AND_ASSERT_THROW_MES(legacy_in_amounts.size() + sp_in_amounts.size() > 0,
         "SpTxSquashedV1: tried to make mock tx without any inputs.");
     CHECK_AND_ASSERT_THROW_MES(out_amounts.size() > 0, "SpTxSquashedV1: tried to make mock tx without any outputs.");

--- a/src/seraphis_mocks/make_mock_tx.cpp
+++ b/src/seraphis_mocks/make_mock_tx.cpp
@@ -64,12 +64,8 @@ namespace sp
 namespace mocks
 {
 //-------------------------------------------------------------------------------------------------------------------
-template <>
-void make_mock_tx<SpTxCoinbaseV1>(const SpTxParamPackV1 &params,
-    const std::vector<rct::xmr_amount>&,
-    const std::vector<rct::xmr_amount>&,
+void make_mock_coinbase_tx(const SpTxParamPackV1 &params,
     const std::vector<rct::xmr_amount> &out_amounts,
-    const DiscretizedFee,
     MockLedgerContext &ledger_context_inout,
     SpTxCoinbaseV1 &tx_out)
 {
@@ -107,6 +103,18 @@ void make_mock_tx<SpTxCoinbaseV1>(const SpTxParamPackV1 &params,
         std::move(output_enotes),
         std::move(tx_supplement),
         tx_out);
+}
+//-------------------------------------------------------------------------------------------------------------------
+template <>
+void make_mock_tx<SpTxCoinbaseV1>(const SpTxParamPackV1 &params,
+    const std::vector<rct::xmr_amount>&,
+    const std::vector<rct::xmr_amount>&,
+    const std::vector<rct::xmr_amount> &out_amounts,
+    const DiscretizedFee,
+    MockLedgerContext &ledger_context_inout,
+    SpTxCoinbaseV1 &tx_out)
+{
+    return make_mock_coinbase_tx(params, out_amounts, ledger_context_inout, tx_out);
 }
 //-------------------------------------------------------------------------------------------------------------------
 template <>

--- a/src/seraphis_mocks/make_mock_tx.cpp
+++ b/src/seraphis_mocks/make_mock_tx.cpp
@@ -66,38 +66,24 @@ namespace mocks
 //-------------------------------------------------------------------------------------------------------------------
 template <>
 void make_mock_tx<SpTxCoinbaseV1>(const SpTxParamPackV1 &params,
-    const std::vector<rct::xmr_amount> &legacy_in_amounts,
-    const std::vector<rct::xmr_amount> &sp_in_amounts,
+    const std::vector<rct::xmr_amount>&,
+    const std::vector<rct::xmr_amount>&,
     const std::vector<rct::xmr_amount> &out_amounts,
-    const DiscretizedFee discretized_transaction_fee,
+    const DiscretizedFee,
     MockLedgerContext &ledger_context_inout,
     SpTxCoinbaseV1 &tx_out)
 {
     CHECK_AND_ASSERT_THROW_MES(out_amounts.size() > 0, "SpTxCoinbaseV1: tried to make mock tx without any outputs.");
-    CHECK_AND_ASSERT_THROW_MES(discretized_transaction_fee == rct::xmr_amount{0},
-        "SpTxCoinbaseV1: tried to make mock tx with nonzero fee.");
 
     // 1. mock semantics version
     const SpTxCoinbaseV1::SemanticRulesVersion semantic_rules_version{SpTxCoinbaseV1::SemanticRulesVersion::MOCK};
 
-    // 2. set block reward from input amounts
-    rct::xmr_amount block_reward{0};
-
-    for (const rct::xmr_amount &input_amount : legacy_in_amounts)
-        block_reward += input_amount;
-    for (const rct::xmr_amount &input_amount : sp_in_amounts)
-        block_reward += input_amount;
-
-    // 3. make mock outputs
+    // 2. make mock outputs
     std::vector<SpCoinbaseOutputProposalV1> output_proposals{
             gen_mock_sp_coinbase_output_proposals_v1(out_amounts, params.num_random_memo_elements)
         };
 
-    // 4. expect amounts to balance
-    CHECK_AND_ASSERT_THROW_MES(balance_check_in_out_amnts_v1(block_reward, output_proposals),
-        "SpTxCoinbaseV1: tried to make mock tx with unbalanced amounts.");
-
-    // 5. make partial memo
+    // 3. make partial memo
     std::vector<ExtraFieldElement> additional_memo_elements;
     additional_memo_elements.resize(params.num_random_memo_elements);
 
@@ -107,18 +93,17 @@ void make_mock_tx<SpTxCoinbaseV1>(const SpTxParamPackV1 &params,
     TxExtra partial_memo;
     make_tx_extra(std::move(additional_memo_elements), partial_memo);
 
-    // 6. extract info from output proposals
+    // 4. extract info from output proposals
     std::vector<SpCoinbaseEnoteV1> output_enotes;
     SpTxSupplementV1 tx_supplement;
     make_v1_coinbase_outputs_v1(output_proposals, output_enotes, tx_supplement.output_enote_ephemeral_pubkeys);
 
-    // 7. collect full memo
+    // 5. collect full memo
     finalize_tx_extra_v1(partial_memo, output_proposals, tx_supplement.tx_extra);
 
-    // 8. finish tx
+    // 6. finish tx
     make_seraphis_tx_coinbase_v1(semantic_rules_version,
         ledger_context_inout.chain_height() + 1,  //next block
-        block_reward,
         std::move(output_enotes),
         std::move(tx_supplement),
         tx_out);

--- a/src/seraphis_mocks/make_mock_tx.h
+++ b/src/seraphis_mocks/make_mock_tx.h
@@ -34,6 +34,7 @@
 
 //local headers
 #include "seraphis_core/binned_reference_set.h"
+#include "seraphis_core/discretized_fee.h"
 
 //third party headers
 
@@ -44,7 +45,6 @@
 namespace rct { using xmr_amount = uint64_t; }
 namespace sp
 {
-    struct DiscretizedFee;
     struct SpTxCoinbaseV1;
     struct SpTxSquashedV1;
     class TxValidationContext;
@@ -64,19 +64,11 @@ namespace mocks
 * type: SpTxType - 
 * type: SpTxParamsT -
 * param: params -
-* param: legacy_in_amounts -
-* param: sp_in_amounts -
-* param: out_amounts -
-* param: discretized_transaction_fee -
 * inoutparam: ledger_context_inout -
 * outparam: tx_out -
 */
 template <typename SpTxType, typename SpTxParamsT>
 void make_mock_tx(const SpTxParamsT &params,
-    const std::vector<rct::xmr_amount> &legacy_in_amounts,
-    const std::vector<rct::xmr_amount> &sp_in_amounts,
-    const std::vector<rct::xmr_amount> &out_amounts,
-    const DiscretizedFee discretized_transaction_fee,
     MockLedgerContext &ledger_context_inout,
     SpTxType &tx_out);
 
@@ -90,27 +82,19 @@ struct SpTxParamPackV1
     std::size_t ref_set_decomp_m{0};
     std::size_t num_random_memo_elements{0};
     SpBinnedReferenceSetConfigV1 bin_config{0, 0};
+    std::vector<rct::xmr_amount> legacy_input_amounts{};
+    std::vector<rct::xmr_amount> sp_input_amounts{};
+    std::vector<rct::xmr_amount> output_amounts{};
+    DiscretizedFee discretized_fee{sp::discretize_fee(0)};
 };
 /// make an SpTxCoinbaseV1 transaction
-void make_mock_coinbase_tx(const SpTxParamPackV1 &params,
-    const std::vector<rct::xmr_amount> &out_amounts,
-    MockLedgerContext &ledger_context_inout,
-    SpTxCoinbaseV1 &tx_out);
 template <>
 void make_mock_tx<SpTxCoinbaseV1>(const SpTxParamPackV1 &params,
-    const std::vector<rct::xmr_amount> &legacy_in_amounts,
-    const std::vector<rct::xmr_amount> &sp_in_amounts,
-    const std::vector<rct::xmr_amount> &out_amounts,
-    const DiscretizedFee discretized_transaction_fee,
     MockLedgerContext &ledger_context_inout,
     SpTxCoinbaseV1 &tx_out);
 /// make an SpTxSquashedV1 transaction
 template <>
 void make_mock_tx<SpTxSquashedV1>(const SpTxParamPackV1 &params,
-    const std::vector<rct::xmr_amount> &legacy_in_amounts,
-    const std::vector<rct::xmr_amount> &sp_in_amounts,
-    const std::vector<rct::xmr_amount> &out_amounts,
-    const DiscretizedFee discretized_transaction_fee,
     MockLedgerContext &ledger_context_inout,
     SpTxSquashedV1 &tx_out);
 

--- a/src/seraphis_mocks/make_mock_tx.h
+++ b/src/seraphis_mocks/make_mock_tx.h
@@ -92,6 +92,10 @@ struct SpTxParamPackV1
     SpBinnedReferenceSetConfigV1 bin_config{0, 0};
 };
 /// make an SpTxCoinbaseV1 transaction
+void make_mock_coinbase_tx(const SpTxParamPackV1 &params,
+    const std::vector<rct::xmr_amount> &out_amounts,
+    MockLedgerContext &ledger_context_inout,
+    SpTxCoinbaseV1 &tx_out);
 template <>
 void make_mock_tx<SpTxCoinbaseV1>(const SpTxParamPackV1 &params,
     const std::vector<rct::xmr_amount> &legacy_in_amounts,

--- a/src/seraphis_mocks/mock_send_receive.cpp
+++ b/src/seraphis_mocks/mock_send_receive.cpp
@@ -139,7 +139,6 @@ void send_sp_coinbase_amounts_to_user(const std::vector<rct::xmr_amount> &coinba
     // 1. prepare payment proposals
     std::vector<jamtis::JamtisPaymentProposalV1> payment_proposals;
     payment_proposals.reserve(coinbase_amounts.size());
-    rct::xmr_amount block_reward{0};
 
     for (const rct::xmr_amount coinbase_amount : coinbase_amounts)
     {
@@ -148,16 +147,12 @@ void send_sp_coinbase_amounts_to_user(const std::vector<rct::xmr_amount> &coinba
         user_address,
         TxExtra{},
         tools::add_element(payment_proposals));
-
-        // b. accumulate the block reward
-        block_reward += coinbase_amount;
     }
 
     // 2. make a coinbase tx
     SpTxCoinbaseV1 coinbase_tx;
     make_seraphis_tx_coinbase_v1(SpTxCoinbaseV1::SemanticRulesVersion::MOCK,
         ledger_context_inout.chain_height() + 1,
-        block_reward,
         std::move(payment_proposals),
         {},
         coinbase_tx);
@@ -181,7 +176,6 @@ void send_sp_coinbase_amounts_to_users(const std::vector<std::vector<rct::xmr_am
     // 1. prepare payment proposals
     std::vector<jamtis::JamtisPaymentProposalV1> payment_proposals;
     payment_proposals.reserve(coinbase_amounts_per_user.size());
-    rct::xmr_amount block_reward{0};
 
     for (std::size_t user_index{0}; user_index < user_addresses.size(); ++user_index)
     {
@@ -192,9 +186,6 @@ void send_sp_coinbase_amounts_to_users(const std::vector<std::vector<rct::xmr_am
                 user_addresses[user_index],
                 TxExtra{},
                 tools::add_element(payment_proposals));
-
-            // b. accumulate the block reward
-            block_reward += user_amount;
         }
     }
 
@@ -202,7 +193,6 @@ void send_sp_coinbase_amounts_to_users(const std::vector<std::vector<rct::xmr_am
     SpTxCoinbaseV1 coinbase_tx;
     make_seraphis_tx_coinbase_v1(SpTxCoinbaseV1::SemanticRulesVersion::MOCK,
         ledger_context_inout.chain_height() + 1,
-        block_reward,
         std::move(payment_proposals),
         {},
         coinbase_tx);

--- a/tests/performance_tests/seraphis_tx.h
+++ b/tests/performance_tests/seraphis_tx.h
@@ -317,14 +317,14 @@ public:
                                 sp::math::uint_pow(params.n, params.m / 2)
                             )
                     };  //bin config must be compatible with n^m
+                tx_params.legacy_input_amounts = std::move(legacy_input_amounts);
+                tx_params.sp_input_amounts = std::move(sp_input_amounts);
+                tx_params.output_amounts = std::move(output_amounts);
+                tx_params.discretized_fee = sp::discretize_fee(0);
 
                 // make tx
                 m_txs.emplace_back();
                 sp::mocks::make_mock_tx<SpTxType>(tx_params,
-                    legacy_input_amounts,
-                    sp_input_amounts,
-                    output_amounts,
-                    sp::discretize_fee(0),
                     *m_ledger_contex,
                     m_txs.back());
 

--- a/tests/unit_tests/seraphis_serialization.cpp
+++ b/tests/unit_tests/seraphis_serialization.cpp
@@ -116,7 +116,7 @@ TEST(seraphis_serialization_demo, seraphis_coinbase_standard)
 
     // make a tx
     SpTxCoinbaseV1 tx;
-    make_mock_tx<SpTxCoinbaseV1>(SpTxParamPackV1{}, {1}, {}, {1}, discretize_fee(0), ledger_context, tx);
+    make_mock_tx<SpTxCoinbaseV1>(SpTxParamPackV1{.output_amounts = {1}}, ledger_context, tx);
 
     // convert the tx to serializable form
     sp::serialization::ser_SpTxCoinbaseV1 serializable_tx;
@@ -161,6 +161,10 @@ TEST(seraphis_serialization_demo, seraphis_squashed_standard)
             .bin_radius = 1,
             .num_bin_members = 1
         };
+    tx_params.legacy_input_amounts = {1};
+    tx_params.sp_input_amounts = {2, 3};
+    tx_params.output_amounts = {3};
+    tx_params.discretized_fee = discretize_fee(3);
 
     // ledger context
     MockLedgerContext ledger_context{0, 10000};
@@ -169,10 +173,6 @@ TEST(seraphis_serialization_demo, seraphis_squashed_standard)
     // make a tx
     SpTxSquashedV1 tx;
     make_mock_tx<SpTxSquashedV1>(tx_params,
-        {1}, //legacy inputs
-        {2, 3}, //seraphis inputs
-        {3}, //outputs
-        discretize_fee(3), //fee
         ledger_context,
         tx);
 

--- a/tests/unit_tests/seraphis_tx.cpp
+++ b/tests/unit_tests/seraphis_tx.cpp
@@ -93,14 +93,14 @@ static void run_mock_tx_test(const std::size_t legacy_ring_size,
         tx_params.ref_set_decomp_m         = ref_set_decomp_m;
         tx_params.num_random_memo_elements = 0;
         tx_params.bin_config               = bin_config;
+        tx_params.legacy_input_amounts     = std::move(legacy_input_amounts);
+        tx_params.sp_input_amounts         = std::move(sp_input_amounts);
+        tx_params.output_amounts           = std::move(output_amounts);
+        tx_params.discretized_fee          = discretized_transaction_fee;
 
         // make tx
         SpTxType tx;
         make_mock_tx<SpTxType>(tx_params,
-            legacy_input_amounts,
-            sp_input_amounts,
-            output_amounts,
-            discretized_transaction_fee,
             ledger_context_inout,
             tx);
 
@@ -186,19 +186,20 @@ static void run_mock_tx_test_batch(const std::vector<SpTxGenData> &gen_data)
                 expected_result = gen.expected_result;
 
                 // mock params
-                SpTxParamPackV1 tx_params;
+                SpTxParamPackV1 tx_params{};
 
-                tx_params.legacy_ring_size = gen.legacy_ring_size;
-                tx_params.ref_set_decomp_n = gen.ref_set_decomp_n;
-                tx_params.ref_set_decomp_m = gen.ref_set_decomp_m;
-                tx_params.bin_config = gen.bin_config;
+                tx_params.legacy_ring_size         = gen.legacy_ring_size;
+                tx_params.ref_set_decomp_n         = gen.ref_set_decomp_n;
+                tx_params.ref_set_decomp_m         = gen.ref_set_decomp_m;
+                tx_params.num_random_memo_elements = 0;
+                tx_params.bin_config               = gen.bin_config;
+                tx_params.legacy_input_amounts     = std::move(legacy_input_amounts);
+                tx_params.sp_input_amounts         = std::move(sp_input_amounts);
+                tx_params.output_amounts           = std::move(gen.output_amounts);
+                tx_params.discretized_fee          = gen.discretized_transaction_fee;
 
                 // make tx
                 make_mock_tx<SpTxType>(tx_params,
-                    legacy_input_amounts,
-                    sp_input_amounts,
-                    gen.output_amounts,
-                    gen.discretized_transaction_fee,
                     ledger_context,
                     tools::add_element(txs_to_verify));
             }
@@ -274,20 +275,21 @@ static void run_mock_tx_test_cached(const std::size_t legacy_ring_size,
     try
     {
         // mock params
-        SpTxParamPackV1 tx_params;
+        SpTxParamPackV1 tx_params{};
 
-        tx_params.legacy_ring_size = legacy_ring_size;
-        tx_params.ref_set_decomp_n = ref_set_decomp_n;
-        tx_params.ref_set_decomp_m = ref_set_decomp_m;
-        tx_params.bin_config = bin_config;
+        tx_params.legacy_ring_size         = legacy_ring_size;
+        tx_params.ref_set_decomp_n         = ref_set_decomp_n;
+        tx_params.ref_set_decomp_m         = ref_set_decomp_m;
+        tx_params.num_random_memo_elements = 0;
+        tx_params.bin_config               = bin_config;
+        tx_params.legacy_input_amounts     = std::move(legacy_input_amounts);
+        tx_params.sp_input_amounts         = std::move(sp_input_amounts);
+        tx_params.output_amounts           = std::move(output_amounts);
+        tx_params.discretized_fee          = discretized_transaction_fee;
 
         // make tx
         SpTxType tx;
         make_mock_tx<SpTxType>(tx_params,
-            legacy_input_amounts,
-            sp_input_amounts,
-            output_amounts,
-            discretized_transaction_fee,
             ledger_context_inout,
             tx);
 


### PR DESCRIPTION
Not storing/serializing `block_reward` saves us a few bytes on coinbase transactions, and makes it so that you can't initialize a coinbase transaction that has a block reward not matching its output sum.