### PR TITLE
SpTxSquashedV1: simplify txid

### DIFF
--- a/src/seraphis_main/tx_builders_mixed.cpp
+++ b/src/seraphis_main/tx_builders_mixed.cpp
@@ -721,7 +721,7 @@ void make_tx_proposal_prefix_v1(const SpTxSquashedV1 &tx, rct::key &tx_proposal_
         tx_proposal_prefix_out);
 }
 //-------------------------------------------------------------------------------------------------------------------
-void make_tx_proofs_prefix_v1(const SpBalanceProofV1 &balance_proof,
+void make_tx_proofs_merkle_root_v1(const SpBalanceProofV1 &balance_proof,
     const std::vector<LegacyRingSignatureV4> &legacy_ring_signatures,
     const std::vector<SpImageProofV1> &sp_image_proofs,
     const std::vector<SpMembershipProofV1> &sp_membership_proofs,
@@ -745,21 +745,6 @@ void make_tx_proofs_prefix_v1(const SpBalanceProofV1 &balance_proof,
     transcript.append("sp_membership_proofs", sp_membership_proofs);
 
     sp_hash_to_32(transcript.data(), transcript.size(), tx_proofs_prefix_out.bytes);
-}
-//-------------------------------------------------------------------------------------------------------------------
-void make_tx_artifacts_merkle_root_v1(const rct::key &input_images_prefix,
-    const rct::key &tx_proofs_prefix,
-    rct::key &tx_artifacts_merkle_root_out)
-{
-    // H_32(input images prefix, tx proofs prefix)
-    SpFSTranscript transcript{
-            config::HASH_KEY_SERAPHIS_TX_ARTIFACTS_MERKLE_ROOT_V1,
-            2*sizeof(rct::key)
-        };
-    transcript.append("input_images_prefix", input_images_prefix);
-    transcript.append("tx_proofs_prefix", tx_proofs_prefix);
-
-    sp_hash_to_32(transcript.data(), transcript.size(), tx_artifacts_merkle_root_out.bytes);
 }
 //-------------------------------------------------------------------------------------------------------------------
 void check_v1_coinbase_tx_proposal_semantics_v1(const SpCoinbaseTxProposalV1 &tx_proposal)

--- a/src/seraphis_main/tx_builders_mixed.h
+++ b/src/seraphis_main/tx_builders_mixed.h
@@ -108,7 +108,7 @@ void make_tx_proposal_prefix_v1(const tx_version_t &tx_version,
     rct::key &tx_proposal_prefix_out);
 void make_tx_proposal_prefix_v1(const SpTxSquashedV1 &tx, rct::key &tx_proposal_prefix_out);
 /**
-* brief: make_tx_proofs_prefix_v1 - hash of all proofs in a tx (e.g. for use in making a tx id)
+* brief: make_tx_proofs_merkle_root_v1 - hash of all proofs in a tx (e.g. for use in making a tx id)
 *   - H_32(balance proof, legacy ring signatures, seraphis image proofs, seraphis membership proofs)
 * param: balance_proof -
 * param: legacy_ring_signatures -
@@ -116,21 +116,11 @@ void make_tx_proposal_prefix_v1(const SpTxSquashedV1 &tx, rct::key &tx_proposal_
 * param: sp_membership_proofs -
 * outparam: tx_proofs_prefix_out -
 */
-void make_tx_proofs_prefix_v1(const SpBalanceProofV1 &balance_proof,
+void make_tx_proofs_merkle_root_v1(const SpBalanceProofV1 &balance_proof,
     const std::vector<LegacyRingSignatureV4> &legacy_ring_signatures,
     const std::vector<SpImageProofV1> &sp_image_proofs,
     const std::vector<SpMembershipProofV1> &sp_membership_proofs,
     rct::key &tx_proofs_prefix_out);
-/**
-* brief: make_tx_artifacts_merkle_root_v1 - merkle root of transaction artifacts (input images and proofs)
-*   - H_32(input images prefix, tx proofs prefix)
-* param: input_images_prefix -
-* param: tx_proofs_prefix -
-* outparam: tx_artifacts_merkle_root_out -
-*/
-void make_tx_artifacts_merkle_root_v1(const rct::key &input_images_prefix,
-    const rct::key &tx_proofs_prefix,
-    rct::key &tx_artifacts_merkle_root_out);
 /**
 * brief: check_v1_coinbase_tx_proposal_semantics_v1 - check semantics of a coinbase tx proposal
 *   - throws if a check fails

--- a/src/seraphis_main/txtype_squashed_v1.cpp
+++ b/src/seraphis_main/txtype_squashed_v1.cpp
@@ -222,40 +222,27 @@ std::size_t sp_tx_squashed_v1_weight(const SpTxSquashedV1 &tx)
 //-------------------------------------------------------------------------------------------------------------------
 void get_sp_tx_squashed_v1_txid(const SpTxSquashedV1 &tx, rct::key &tx_id_out)
 {
-    // tx_id = H_32(tx_proposal_prefix, tx_artifacts_merkle_root)
+    // tx_id = H_32(tx_proposal_prefix, tx_proofs_merkle_root)
 
     // 1. tx proposal prefix
     // H_32(tx version, legacy input key images, seraphis input key images, output enotes, fee, tx supplement)
     rct::key tx_proposal_prefix;
     make_tx_proposal_prefix_v1(tx, tx_proposal_prefix);
 
-    // 2. input images prefix
-    // - note: key images are represented in the tx id twice (tx proposal prefix and input images
-    //   - the reasons are: A) decouple proposals from the enote image structure, B) don't require proposals to commit
-    //     to input commitment masks
-    // H_32({C", KI}((legacy)), {K", C", KI}((seraphis)))
-    rct::key input_images_prefix;
-    make_input_images_prefix_v1(tx.legacy_input_images, tx.sp_input_images, input_images_prefix);
-
-    // 3. tx proofs prefix
+    // 2. tx proofs merkle root
     // H_32(balance proof, legacy ring signatures, image proofs, seraphis membership proofs)
-    rct::key tx_proofs_prefix;
-    make_tx_proofs_prefix_v1(tx.balance_proof,
+    rct::key tx_proofs_merkle_root;
+    make_tx_proofs_merkle_root_v1(tx.balance_proof,
         tx.legacy_ring_signatures,
         tx.sp_image_proofs,
         tx.sp_membership_proofs,
-        tx_proofs_prefix);
+        tx_proofs_merkle_root);
 
-    // 4. tx artifacts prefix
-    // H_32(input images prefix, tx proofs prefix)
-    rct::key tx_artifacts_merkle_root;
-    make_tx_artifacts_merkle_root_v1(input_images_prefix, tx_proofs_prefix, tx_artifacts_merkle_root);
-
-    // 5. tx id
-    // tx_id = H_32(tx_proposal_prefix, tx_artifacts_merkle_root)
+    // 3. tx id
+    // tx_id = H_32(tx_proposal_prefix, tx_proofs_merkle_root)
     SpFSTranscript transcript{config::HASH_KEY_SERAPHIS_TRANSACTION_TYPE_SQUASHED_V1, 2*sizeof(rct::key)};
     transcript.append("prefix", tx_proposal_prefix);
-    transcript.append("artifacts", tx_artifacts_merkle_root);
+    transcript.append("tx_proofs_merkle_root", tx_proofs_merkle_root);
 
     assert(transcript.size() <= 128 && "sp squashed v1 tx id must fit within one blake2b block (128 bytes).");
     sp_hash_to_32(transcript.data(), transcript.size(), tx_id_out.bytes);


### PR DESCRIPTION
We got rid of the tx artifacts hash. The reason for it was a follows:
```
note: key images are represented in the tx id twice (tx proposal prefix and input images
-    //   - the reasons are: A) decouple proposals from the enote image structure, B) don't require proposals to commit
-    //     to input commitment masks
```

Input proposals DO commit to input commitment masks though (see `SpInputProposalCore`). Does the txid hash indirection still serve a purpose or could we make the txid faster?