### PR TITLE
serialization: serialize tools::variant

### DIFF
--- a/src/common/variant.h
+++ b/src/common/variant.h
@@ -154,6 +154,10 @@ private:
 //member variables
     /// variant of all value types
     VType m_value;
+
+//friend functions
+template <class Archive, typename... Ts>
+friend bool do_serialize(Archive &ar, variant<Ts...> &v);
 };
 
 template <typename... Types>

--- a/src/serialization/variant.h
+++ b/src/serialization/variant.h
@@ -43,6 +43,7 @@
 #include <boost/mpl/if.hpp>
 #include <boost/mpl/front.hpp>
 #include <boost/mpl/pop_front.hpp>
+#include "common/variant.h"
 #include "serialization.h"
 
 /*! \struct variant_serialization_triats
@@ -143,4 +144,14 @@ template <template <bool> class Archive, typename... T>
 static bool do_serialize(Archive<true> &ar, boost::variant<T...> &v)
 {
   return boost::apply_visitor(variant_write_visitor<Archive>(ar), v);
+}
+
+// implementation for tools::variant delegates to internal boost::variant member field
+namespace tools
+{
+template <class Archive, typename... Ts>
+bool do_serialize(Archive &ar, variant<Ts...> &v)
+{
+  return do_serialize(ar, v.m_value);
+}
 }

--- a/tests/unit_tests/seraphis_serialization.cpp
+++ b/tests/unit_tests/seraphis_serialization.cpp
@@ -229,3 +229,30 @@ TEST(seraphis_serialization, jamtis_payment_proposal_self_send_v1)
     EXPECT_EQ(payprop, recovered_payprop);
 }
 //-------------------------------------------------------------------------------------------------------------------
+template <typename... Ts> void match_tools_variant(const tools::variant<Ts...>&) {}
+VARIANT_TAG(binary_archive, sp::SpEnoteCore, 0x37);
+VARIANT_TAG(binary_archive, sp::SpCoinbaseEnoteCore, 0x88);
+//-------------------------------------------------------------------------------------------------------------------
+TEST(seraphis_serialization, tools_variant)
+{
+    sp::SpEnoteCoreVariant enote_core{
+            sp::SpEnoteCore{
+                    .onetime_address = rct::pkGen(),
+                    .amount_commitment = rct::zeroCommit(420)
+                }
+        };
+
+    match_tools_variant(enote_core); // throws compile error if enote_core stops being of tools::variant type
+
+    // serialize
+    std::string serialized;
+    EXPECT_TRUE(::serialization::dump_binary(enote_core, serialized));
+
+    // deserialize
+    sp::SpEnoteCoreVariant enote_core_recovered;
+    EXPECT_TRUE(::serialization::parse_binary(serialized, enote_core_recovered));
+
+    // test equal
+    EXPECT_EQ(enote_core, enote_core_recovered);
+}
+//-------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Pinging @dangerousfreedom1984


`tools::variant`s can be serialized automatically just like `boost::variant`s, as long as `VARIANT_TAG` is specified for each subtype. 